### PR TITLE
PRL-4261_list_of_judges_from_refdata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -601,7 +601,8 @@ def sonarExclusions = [
   '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndApplicantsChecker.java',
   '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndRespondentsChecker.java',
   '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndOtherPeopleInThisApplicationChecker.java',
-  '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndApplicantsChecker.java'
+  '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndApplicantsChecker.java',
+  '**/uk/gov/hmcts/reform/prl/services/ManageOrderService.java'
 ]
 
 sonarqube {

--- a/build.gradle
+++ b/build.gradle
@@ -601,8 +601,7 @@ def sonarExclusions = [
   '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndApplicantsChecker.java',
   '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndRespondentsChecker.java',
   '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndOtherPeopleInThisApplicationChecker.java',
-  '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndApplicantsChecker.java',
-  '**/uk/gov/hmcts/reform/prl/services/ManageOrderService.java'
+  '**/uk/gov/hmcts/reform/prl/services/validators/ChildrenAndApplicantsChecker.java'
 ]
 
 sonarqube {

--- a/charts/prl-cos/values.preview.template.yaml
+++ b/charts/prl-cos/values.preview.template.yaml
@@ -37,11 +37,11 @@ java:
     IDAM_CLIENT_REDIRECT_URI: https://prl-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    CORE_CASE_DATA_API_URL: http://prl-ccd-definitions-pr-1489-ccd-data-store-api
+    CORE_CASE_DATA_API_URL: http://prl-ccd-definitions-pr-1586-ccd-data-store-api
     AUTH_IDAM_CLIENT_BASEURL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     DOCMOSIS_SERVICE_BASE_URL: https://docmosis.aat.platform.hmcts.net
-    CCD_CASE_DOCS_AM_API: http://prl-ccd-definitions-pr-1489-cdam
+    CCD_CASE_DOCS_AM_API: http://prl-ccd-definitions-pr-1586-cdam
     XUI_URL: https://manage-case.{{ .Values.global.environment }}.platform.hmcts.net/cases/case-details
     REFORM_SERVICE_NAME: prl_cos_api
     AUTH_PROVIDER_SERVICE_CLIENT_MICROSERVICE: prl_cos_api
@@ -53,9 +53,9 @@ java:
     FACT_API: http://fact-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     LOCATION_REF_API: http://rd-location-ref-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     RD_PROFESSIONAL_API: http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    ACA_SERVICE_API_BASEURL: http://prl-ccd-definitions-pr-1489-aac-manage-case-assignment
+    ACA_SERVICE_API_BASEURL: http://prl-ccd-definitions-pr-1586-aac-manage-case-assignment
     CITIZEN_URL: https://privatelaw.{{ .Values.global.environment }}.platform.hmcts.net
-    BUNDLE_URL: http://prl-ccd-definitions-pr-1489-em-ccdorc
+    BUNDLE_URL: http://prl-ccd-definitions-pr-1586-em-ccdorc
     HEARING_API_BASEURL : http://fis-hmc-api-aat.service.core-compute-aat.internal
     REFDATA_API_URL: http://rd-commondata-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     JUDICIAL_USERS_API: http://rd-judicial-api-aat.service.core-compute-aat.internal

--- a/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/DraftOrdersControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/DraftOrdersControllerFunctionalTest.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -119,7 +118,7 @@ public class DraftOrdersControllerFunctionalTest {
         CaseData caseData = CaseData.builder()
             .caseTypeOfApplication(FL401_CASE_TYPE).id(Long.parseLong("1647373355918192"))
             .build();
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.Yes);
+        when(manageOrderService.checkJudgeOrMagistrateList(any())).thenReturn(YesOrNo.Yes);
         when(manageOrderService.populateCustomOrderFields(any())).thenReturn(caseData);
         mockMvc.perform(post("/populate-draft-order-fields")
                             .contentType(MediaType.APPLICATION_JSON)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/DraftOrdersControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/DraftOrdersControllerFunctionalTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -19,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.prl.ResourceLoader;
+import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.enums.manageorders.C21OrderOptionsEnum;
 import uk.gov.hmcts.reform.prl.enums.manageorders.CreateSelectOrderOptionsEnum;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
@@ -117,6 +119,7 @@ public class DraftOrdersControllerFunctionalTest {
         CaseData caseData = CaseData.builder()
             .caseTypeOfApplication(FL401_CASE_TYPE).id(Long.parseLong("1647373355918192"))
             .build();
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.Yes);
         when(manageOrderService.populateCustomOrderFields(any())).thenReturn(caseData);
         mockMvc.perform(post("/populate-draft-order-fields")
                             .contentType(MediaType.APPLICATION_JSON)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/EditAndApproveDraftOrderControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/EditAndApproveDraftOrderControllerFunctionalTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,10 +15,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.prl.ResourceLoader;
+import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.services.DraftAnOrderService;
+import uk.gov.hmcts.reform.prl.services.ManageOrderService;
 import uk.gov.hmcts.reform.prl.utils.IdamTokenGenerator;
 import uk.gov.hmcts.reform.prl.utils.ServiceAuthenticationGenerator;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
@@ -41,6 +45,9 @@ public class EditAndApproveDraftOrderControllerFunctionalTest {
 
     @MockBean
     private DraftAnOrderService draftAnOrderService;
+
+    @MockBean
+    private ManageOrderService manageOrderService;
 
 
 
@@ -95,6 +102,7 @@ public class EditAndApproveDraftOrderControllerFunctionalTest {
     @Test
     public void givenRequestBody_whenJudge_or_admin_populate_draft_order_custom_fields_then200Response() throws Exception {
         String requestBody = ResourceLoader.loadJson(VALID_DRAFT_ORDER_REQUEST_BODY);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.Yes);
         mockMvc.perform(post("/judge-or-admin-populate-draft-order-custom-fields")
                             .contentType(MediaType.APPLICATION_JSON)
                             .header("Authorization", idamTokenGenerator.generateIdamTokenForSolicitor())

--- a/src/main/java/uk/gov/hmcts/reform/prl/constants/PrlAppsConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/constants/PrlAppsConstants.java
@@ -794,5 +794,5 @@ public class PrlAppsConstants {
     public static final String PM_LOWER_CASE = "pm";
     public static final String PM_UPPER_CASE = "PM";
 
-    public static final String LISTS_DONT_MATCH_ERROR = "Please contact support and update the judicial title list with refdata";
+    public static final String LISTS_DONT_MATCH_ERROR = "Please contact support and update the judicial title list so it is inline with refdata";
 }

--- a/src/main/java/uk/gov/hmcts/reform/prl/constants/PrlAppsConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/constants/PrlAppsConstants.java
@@ -793,4 +793,6 @@ public class PrlAppsConstants {
     public static final String AM_UPPER_CASE = "AM";
     public static final String PM_LOWER_CASE = "pm";
     public static final String PM_UPPER_CASE = "PM";
+
+    public static final String LISTS_DONT_MATCH_ERROR = "Please contact support and update the judicial title list with refdata";
 }

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
@@ -49,7 +49,6 @@ public class DraftAnOrderController {
 
     private final HearingService hearingService;
 
-    @Autowired
     private ManageOrderService manageOrderService;
 
     @Autowired
@@ -101,7 +100,6 @@ public class DraftAnOrderController {
         if (authorisationService.isAuthorized(authorisation,s2sToken)) {
             YesOrNo listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
             List<String> errorList = new ArrayList<>();
-            listMatchesRefData = YesOrNo.Yes;
             if (listMatchesRefData.equals(YesOrNo.No)) {
                 errorList.add(LISTS_DONT_MATCH_ERROR);
                 return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
@@ -49,6 +49,7 @@ public class DraftAnOrderController {
 
     private final HearingService hearingService;
 
+    @Autowired
     private ManageOrderService manageOrderService;
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.prl.constants.PrlAppsConstants;
+import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CallbackResponse;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.services.AuthorisationService;
@@ -31,6 +32,7 @@ import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.INVALID_CLIENT;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTS_DONT_MATCH_ERROR;
 
 @Slf4j
 @RestController
@@ -97,10 +99,10 @@ public class DraftAnOrderController {
         @RequestBody CallbackRequest callbackRequest
     ) throws Exception {
         if (authorisationService.isAuthorized(authorisation,s2sToken)) {
-            boolean listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
+            YesOrNo listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
             List<String> errorList = new ArrayList<>();
-            if (listMatchesRefData == false) {
-                errorList.add("The List does not match RefData");
+            if (listMatchesRefData.equals(YesOrNo.No)) {
+                errorList.add(LISTS_DONT_MATCH_ERROR);
                 return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();
             }
             return AboutToStartOrSubmitCallbackResponse.builder()

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
@@ -101,6 +101,7 @@ public class DraftAnOrderController {
         if (authorisationService.isAuthorized(authorisation,s2sToken)) {
             YesOrNo listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
             List<String> errorList = new ArrayList<>();
+            listMatchesRefData = YesOrNo.Yes;
             if (listMatchesRefData.equals(YesOrNo.No)) {
                 errorList.add(LISTS_DONT_MATCH_ERROR);
                 return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderController.java
@@ -47,7 +47,8 @@ public class DraftAnOrderController {
 
     private final HearingService hearingService;
 
-    private final ManageOrderService manageOrderService;
+    @Autowired
+    private ManageOrderService manageOrderService;
 
     @Autowired
     private AuthorisationService authorisationService;
@@ -96,6 +97,12 @@ public class DraftAnOrderController {
         @RequestBody CallbackRequest callbackRequest
     ) throws Exception {
         if (authorisationService.isAuthorized(authorisation,s2sToken)) {
+            boolean listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
+            List<String> errorList = new ArrayList<>();
+            if (listMatchesRefData == false) {
+                errorList.add("The List does not match RefData");
+                return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();
+            }
             return AboutToStartOrSubmitCallbackResponse.builder()
                 .data(draftAnOrderService.handlePopulateDraftOrderFields(callbackRequest, authorisation)).build();
         }  else {

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/EditAndApproveDraftOrderController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/EditAndApproveDraftOrderController.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.prl.constants.PrlAppsConstants;
 import uk.gov.hmcts.reform.prl.enums.Event;
+import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.enums.manageorders.CreateSelectOrderOptionsEnum;
 import uk.gov.hmcts.reform.prl.models.DraftOrder;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
@@ -39,6 +40,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.INVALID_CLIENT;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.JURISDICTION;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTS_DONT_MATCH_ERROR;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.STATE;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.Yes;
 
@@ -172,6 +174,12 @@ public class EditAndApproveDraftOrderController {
         @RequestHeader(PrlAppsConstants.SERVICE_AUTHORIZATION_HEADER) String s2sToken,
         @RequestBody CallbackRequest callbackRequest) throws  Exception {
         if (authorisationService.isAuthorized(authorisation,s2sToken)) {
+            YesOrNo listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
+            List<String> errorList = new ArrayList<>();
+            if (listMatchesRefData.equals(YesOrNo.No)) {
+                errorList.add(LISTS_DONT_MATCH_ERROR);
+                return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();
+            }
             CaseData caseData = objectMapper.convertValue(
                 callbackRequest.getCaseDetails().getData(),
                 CaseData.class

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
@@ -133,7 +133,6 @@ public class ManageOrdersController {
         if (authorisationService.isAuthorized(authorisation, s2sToken)) {
             boolean listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
             List<String> errorList = new ArrayList<>();
-            log.info("listMatchesRefData {}", listMatchesRefData);
             if (listMatchesRefData == false) {
                 errorList.add("The List does not match RefData");
                 return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
@@ -131,6 +131,13 @@ public class ManageOrdersController {
         @RequestHeader(PrlAppsConstants.SERVICE_AUTHORIZATION_HEADER) String s2sToken,
         @RequestBody CallbackRequest callbackRequest) throws Exception {
         if (authorisationService.isAuthorized(authorisation, s2sToken)) {
+            boolean listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
+            List<String> errorList = new ArrayList<>();
+            log.info("listMatchesRefData {}", listMatchesRefData);
+            if (listMatchesRefData == false) {
+                errorList.add("The List does not match RefData");
+                return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();
+            }
             return AboutToStartOrSubmitCallbackResponse.builder().data(manageOrderService.handlePreviewOrder(
                 callbackRequest,
                 authorisation)).build();

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
@@ -66,8 +66,10 @@ import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DIO_URGENT_HEAR
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DIO_WITHOUT_NOTICE_HEARING_DETAILS;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.INVALID_CLIENT;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.JURISDICTION;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTS_DONT_MATCH_ERROR;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.ORDER_HEARING_DETAILS;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.STATE;
+import static uk.gov.hmcts.reform.prl.enums.YesOrNo.No;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.Yes;
 import static uk.gov.hmcts.reform.prl.enums.manageorders.ManageOrdersOptionsEnum.amendOrderUnderSlipRule;
 import static uk.gov.hmcts.reform.prl.enums.manageorders.ManageOrdersOptionsEnum.createAnOrder;
@@ -131,10 +133,10 @@ public class ManageOrdersController {
         @RequestHeader(PrlAppsConstants.SERVICE_AUTHORIZATION_HEADER) String s2sToken,
         @RequestBody CallbackRequest callbackRequest) throws Exception {
         if (authorisationService.isAuthorized(authorisation, s2sToken)) {
-            boolean listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
+            YesOrNo listMatchesRefData = manageOrderService.checkJudgeOrMagistrateList(authorisation);
             List<String> errorList = new ArrayList<>();
-            if (listMatchesRefData == false) {
-                errorList.add("The List does not match RefData");
+            if (listMatchesRefData.equals(No)) {
+                errorList.add(LISTS_DONT_MATCH_ERROR);
                 return AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build();
             }
             return AboutToStartOrSubmitCallbackResponse.builder().data(manageOrderService.handlePreviewOrder(
@@ -389,7 +391,7 @@ public class ManageOrdersController {
 
 
     private static void setIsWithdrawnRequestSent(CaseData caseData, Map<String, Object> caseDataUpdated) {
-        if ((YesOrNo.No).equals(caseData.getManageOrders().getIsCaseWithdrawn())) {
+        if ((No).equals(caseData.getManageOrders().getIsCaseWithdrawn())) {
             caseDataUpdated.put("isWithdrawRequestSent", "DisApproved");
         } else {
             caseDataUpdated.put("isWithdrawRequestSent", "Approved");
@@ -490,7 +492,7 @@ public class ManageOrdersController {
                 );
                 manageOrderService.populateServeOrderDetails(modifiedCaseData, caseDataUpdated);
             } else {
-                caseDataUpdated.put("ordersNeedToBeServed", YesOrNo.No);
+                caseDataUpdated.put("ordersNeedToBeServed", No);
             }
             return AboutToStartOrSubmitCallbackResponse.builder()
                 .data(caseDataUpdated)

--- a/src/main/java/uk/gov/hmcts/reform/prl/enums/manageorders/JudgeOrMagistrateTitleEnum.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/enums/manageorders/JudgeOrMagistrateTitleEnum.java
@@ -44,12 +44,6 @@ public enum JudgeOrMagistrateTitleEnum {
     @JsonProperty("justicesClerk")
     justicesClerk("justicesClerk", "Justices' Clerk"),
 
-    @JsonProperty("theHonourableMrsJustice")
-    theHonourableMrsJustice("theHonourableMrsJustice", "The Honourable Mrs Justice"),
-
-    @JsonProperty("theHonourableMrJustice")
-    theHonourableMrJustice("theHonourableMrJustice", "The Honourable Mr Justice"),
-
     @JsonProperty("deputyHighCourtJudge")
     deputyHighCourtJudge("deputyHighCourtJudge","Deputy High Court Judge"),
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/enums/manageorders/JudgeOrMagistrateTitleEnum.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/enums/manageorders/JudgeOrMagistrateTitleEnum.java
@@ -48,7 +48,13 @@ public enum JudgeOrMagistrateTitleEnum {
     theHonourableMrsJustice("theHonourableMrsJustice", "The Honourable Mrs Justice"),
 
     @JsonProperty("theHonourableMrJustice")
-    theHonourableMrJustice("theHonourableMrJustice", "The Honourable Mr Justice");
+    theHonourableMrJustice("theHonourableMrJustice", "The Honourable Mr Justice"),
+
+    @JsonProperty("deputyHighCourtJudge")
+    deputyHighCourtJudge("deputyHighCourtJudge","Deputy High Court Judge"),
+
+    @JsonProperty("highCourtJudge")
+    highCourtJudge("highCourtJudge", "High Court Judge");
 
     private final String id;
     private final String displayedValue;

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -9,6 +9,7 @@ import org.junit.platform.commons.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.prl.constants.PrlAppsConstants;
@@ -509,6 +510,14 @@ public class ManageOrderService {
     @Value("${document.templates.common.prl_c6a_welsh_filename}")
     protected String nopNonPartiesWelshFile;
 
+    @Value("${sendandreply.category-id}")
+    private String categoryId;
+
+    @Value("${sendandreply.service-code}")
+    private String serviceCode;
+
+    private final AuthTokenGenerator authTokenGenerator;
+
     private final DocumentLanguageService documentLanguageService;
 
     public static final String FAMILY_MAN_ID = "Family Man ID: ";
@@ -530,6 +539,9 @@ public class ManageOrderService {
 
     @Autowired
     private final HearingService hearingService;
+
+    @Autowired
+    SendAndReplyService sendAndReplyService;
 
     private final HearingDataService hearingDataService;
 
@@ -2245,6 +2257,11 @@ public class ManageOrderService {
     public Map<String, Object> handlePreviewOrder(CallbackRequest callbackRequest, String authorisation) throws Exception {
         CaseData caseData = CaseUtils.getCaseData(callbackRequest.getCaseDetails(), objectMapper);
         Map<String, Object> caseDataUpdated = callbackRequest.getCaseDetails().getData();
+        DynamicList listOfJudges = sendAndReplyService.getJudiciaryTierDynamicList(authorisation,
+                authTokenGenerator.generate(),
+                serviceCode,
+                categoryId);
+        log.info("list of judges is: {}", listOfJudges);
         if (Event.MANAGE_ORDERS.getId().equals(callbackRequest.getEventId()) && ManageOrdersOptionsEnum.uploadAnOrder.equals(
             caseData.getManageOrdersOptions())) {
             List<DynamicListElement> legalAdviserList = refDataUserService.getLegalAdvisorList();

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2310,7 +2310,7 @@ public class ManageOrderService {
             displayedJudgeValue.add(enumValue.getDisplayedValue());
         }
 
-        log.info("Judge's enum labels are: {}", enumValues);
+        log.info("Judge's enum labels are: {}", displayedJudgeValue);
         log.info("Judge's labels are: {}", listOfJudgesLabels);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2302,6 +2302,7 @@ public class ManageOrderService {
         for (DynamicListElement listItem : listOfJudges.getListItems()) {
             listOfJudgesLabels.add(listItem.getLabel());
         }
+        listOfJudgesLabels.add("testData");
 
         List<JudgeOrMagistrateTitleEnum> enumValues = new ArrayList<>(EnumSet.allOf(JudgeOrMagistrateTitleEnum.class));
         List<String> displayedJudgeValue = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.prl.enums.YesNoDontKnow;
 import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.enums.manageorders.AmendOrderCheckEnum;
 import uk.gov.hmcts.reform.prl.enums.manageorders.CreateSelectOrderOptionsEnum;
+import uk.gov.hmcts.reform.prl.enums.manageorders.JudgeOrMagistrateTitleEnum;
 import uk.gov.hmcts.reform.prl.enums.manageorders.ManageOrdersOptionsEnum;
 import uk.gov.hmcts.reform.prl.enums.manageorders.OrderRecipientsEnum;
 import uk.gov.hmcts.reform.prl.enums.manageorders.SelectTypeOfOrderEnum;
@@ -76,6 +77,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -2257,7 +2259,7 @@ public class ManageOrderService {
     public Map<String, Object> handlePreviewOrder(CallbackRequest callbackRequest, String authorisation) throws Exception {
         CaseData caseData = CaseUtils.getCaseData(callbackRequest.getCaseDetails(), objectMapper);
         Map<String, Object> caseDataUpdated = callbackRequest.getCaseDetails().getData();
-        checkJudgeOrMagistrateList(authorisation);
+        checkJudgeOrMagistrateList(authorisation, caseData);
         if (Event.MANAGE_ORDERS.getId().equals(callbackRequest.getEventId()) && ManageOrdersOptionsEnum.uploadAnOrder.equals(
             caseData.getManageOrdersOptions())) {
             List<DynamicListElement> legalAdviserList = refDataUserService.getLegalAdvisorList();
@@ -2291,7 +2293,7 @@ public class ManageOrderService {
         return caseDataUpdated;
     }
 
-    public void checkJudgeOrMagistrateList(String authorisation) {
+    public void checkJudgeOrMagistrateList(String authorisation, CaseData caseData) {
         DynamicList listOfJudges = sendAndReplyService.getJudiciaryTierDynamicList(authorisation,
                 authTokenGenerator.generate(),
                 serviceCode,
@@ -2302,7 +2304,9 @@ public class ManageOrderService {
             listOfJudgesLabels.add(listItem.getLabel());
         }
 
-        log.info("Judge's labels are: {}", listOfJudgesLabels);
+        List<JudgeOrMagistrateTitleEnum> enumValues = new ArrayList<>(EnumSet.allOf(JudgeOrMagistrateTitleEnum.class));
+
+        log.info("Judge's labels are: {}", enumValues);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2312,7 +2312,7 @@ public class ManageOrderService {
         log.info("listOfJudgesLabels: {}",listOfJudgesLabels);
         log.info("displayedJudgeValue: {}", displayedJudgeValue);
 
-        return displayedJudgeValue.contains(listOfJudgesLabels) ? true : false;
+        return displayedJudgeValue.containsAll(listOfJudgesLabels) ? true : false;
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2297,7 +2297,7 @@ public class ManageOrderService {
                 serviceCode,
                 categoryId);
 
-        List<String> listOfJudgesLabels = null;
+        List<String> listOfJudgesLabels = new ArrayList<>();
         for (DynamicListElement listItem : listOfJudges.getListItems()) {
             listOfJudgesLabels.add(listItem.getLabel());
         }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2257,11 +2257,7 @@ public class ManageOrderService {
     public Map<String, Object> handlePreviewOrder(CallbackRequest callbackRequest, String authorisation) throws Exception {
         CaseData caseData = CaseUtils.getCaseData(callbackRequest.getCaseDetails(), objectMapper);
         Map<String, Object> caseDataUpdated = callbackRequest.getCaseDetails().getData();
-        DynamicList listOfJudges = sendAndReplyService.getJudiciaryTierDynamicList(authorisation,
-                authTokenGenerator.generate(),
-                serviceCode,
-                categoryId);
-        log.info("list of judges is: {}", listOfJudges);
+        checkJudgeOrMagistrateList(authorisation);
         if (Event.MANAGE_ORDERS.getId().equals(callbackRequest.getEventId()) && ManageOrdersOptionsEnum.uploadAnOrder.equals(
             caseData.getManageOrdersOptions())) {
             List<DynamicListElement> legalAdviserList = refDataUserService.getLegalAdvisorList();
@@ -2293,6 +2289,20 @@ public class ManageOrderService {
             ));
         }
         return caseDataUpdated;
+    }
+
+    public void checkJudgeOrMagistrateList(String authorisation) {
+        DynamicList listOfJudges = sendAndReplyService.getJudiciaryTierDynamicList(authorisation,
+                authTokenGenerator.generate(),
+                serviceCode,
+                categoryId);
+
+        List<String> listOfJudgesLabels = null;
+        for (DynamicListElement listItem : listOfJudges.getListItems()) {
+            listOfJudgesLabels.add(listItem.getLabel());
+        }
+
+        log.info("Judge's labels are: {}", listOfJudgesLabels);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -542,8 +542,7 @@ public class ManageOrderService {
     @Autowired
     private final HearingService hearingService;
 
-    @Autowired
-    SendAndReplyService sendAndReplyService;
+    private final SendAndReplyService sendAndReplyService;
 
     private final HearingDataService hearingDataService;
 
@@ -2302,7 +2301,6 @@ public class ManageOrderService {
         for (DynamicListElement listItem : listOfJudges.getListItems()) {
             listOfJudgesLabels.add(listItem.getLabel());
         }
-        listOfJudgesLabels.add("testData");
 
         List<JudgeOrMagistrateTitleEnum> enumValues = new ArrayList<>(EnumSet.allOf(JudgeOrMagistrateTitleEnum.class));
         List<String> displayedJudgeValue = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2309,6 +2309,9 @@ public class ManageOrderService {
             displayedJudgeValue.add(enumValue.getDisplayedValue());
         }
 
+        log.info("listOfJudgesLabels: {}",listOfJudgesLabels);
+        log.info("displayedJudgeValue: {}", displayedJudgeValue);
+
         return displayedJudgeValue.contains(listOfJudgesLabels) ? true : false;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2305,8 +2305,13 @@ public class ManageOrderService {
         }
 
         List<JudgeOrMagistrateTitleEnum> enumValues = new ArrayList<>(EnumSet.allOf(JudgeOrMagistrateTitleEnum.class));
+        List<String> displayedJudgeValue = new ArrayList<>();
+        for (JudgeOrMagistrateTitleEnum enumValue: enumValues) {
+            displayedJudgeValue.add(enumValue.getDisplayedValue());
+        }
 
-        log.info("Judge's labels are: {}", enumValues);
+        log.info("Judge's enum labels are: {}", enumValues);
+        log.info("Judge's labels are: {}", listOfJudgesLabels);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2259,7 +2259,6 @@ public class ManageOrderService {
     public Map<String, Object> handlePreviewOrder(CallbackRequest callbackRequest, String authorisation) throws Exception {
         CaseData caseData = CaseUtils.getCaseData(callbackRequest.getCaseDetails(), objectMapper);
         Map<String, Object> caseDataUpdated = callbackRequest.getCaseDetails().getData();
-        checkJudgeOrMagistrateList(authorisation, caseData);
         if (Event.MANAGE_ORDERS.getId().equals(callbackRequest.getEventId()) && ManageOrdersOptionsEnum.uploadAnOrder.equals(
             caseData.getManageOrdersOptions())) {
             List<DynamicListElement> legalAdviserList = refDataUserService.getLegalAdvisorList();
@@ -2293,7 +2292,7 @@ public class ManageOrderService {
         return caseDataUpdated;
     }
 
-    public void checkJudgeOrMagistrateList(String authorisation, CaseData caseData) {
+    public boolean checkJudgeOrMagistrateList(String authorisation) {
         DynamicList listOfJudges = sendAndReplyService.getJudiciaryTierDynamicList(authorisation,
                 authTokenGenerator.generate(),
                 serviceCode,
@@ -2310,8 +2309,7 @@ public class ManageOrderService {
             displayedJudgeValue.add(enumValue.getDisplayedValue());
         }
 
-        log.info("Judge's enum labels are: {}", displayedJudgeValue);
-        log.info("Judge's labels are: {}", listOfJudgesLabels);
+        return displayedJudgeValue.contains(listOfJudgesLabels) ? true : false;
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2291,7 +2291,7 @@ public class ManageOrderService {
         return caseDataUpdated;
     }
 
-    public boolean checkJudgeOrMagistrateList(String authorisation) {
+    public YesOrNo checkJudgeOrMagistrateList(String authorisation) {
         DynamicList listOfJudges = sendAndReplyService.getJudiciaryTierDynamicList(authorisation,
                 authTokenGenerator.generate(),
                 serviceCode,
@@ -2309,7 +2309,7 @@ public class ManageOrderService {
             displayedJudgeValue.add(enumValue.getDisplayedValue());
         }
 
-        return displayedJudgeValue.containsAll(listOfJudgesLabels) ? true : false;
+        return displayedJudgeValue.containsAll(listOfJudgesLabels) ? Yes : No;
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2301,15 +2301,13 @@ public class ManageOrderService {
         for (DynamicListElement listItem : listOfJudges.getListItems()) {
             listOfJudgesLabels.add(listItem.getLabel());
         }
+        listOfJudgesLabels.add("test");
 
         List<JudgeOrMagistrateTitleEnum> enumValues = new ArrayList<>(EnumSet.allOf(JudgeOrMagistrateTitleEnum.class));
         List<String> displayedJudgeValue = new ArrayList<>();
         for (JudgeOrMagistrateTitleEnum enumValue: enumValues) {
             displayedJudgeValue.add(enumValue.getDisplayedValue());
         }
-
-        log.info("listOfJudgesLabels: {}",listOfJudgesLabels);
-        log.info("displayedJudgeValue: {}", displayedJudgeValue);
 
         return displayedJudgeValue.containsAll(listOfJudgesLabels) ? true : false;
     }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/ManageOrderService.java
@@ -2301,7 +2301,6 @@ public class ManageOrderService {
         for (DynamicListElement listItem : listOfJudges.getListItems()) {
             listOfJudgesLabels.add(listItem.getLabel());
         }
-        listOfJudgesLabels.add("test");
 
         List<JudgeOrMagistrateTitleEnum> enumValues = new ArrayList<>(EnumSet.allOf(JudgeOrMagistrateTitleEnum.class));
         List<String> displayedJudgeValue = new ArrayList<>();

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderControllerTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.prl.constants.PrlAppsConstants;
+import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.enums.dio.DioCafcassOrCymruEnum;
 import uk.gov.hmcts.reform.prl.enums.dio.DioCourtEnum;
 import uk.gov.hmcts.reform.prl.enums.dio.DioHearingsAndNextStepsEnum;
@@ -61,6 +62,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTS_DONT_MATCH_ERROR;
 import static uk.gov.hmcts.reform.prl.enums.Event.ADMIN_EDIT_AND_APPROVE_ORDER;
 
 @PropertySource(value = "classpath:application.yaml")
@@ -120,7 +122,7 @@ public class DraftAnOrderControllerTest {
         when(hearingDataService.getHearingData(Mockito.any(),Mockito.any(),Mockito.any()))
             .thenReturn(List.of(Element.<HearingData>builder().build()));
         when(hearingService.getHearings(Mockito.anyString(),Mockito.anyString())).thenReturn(Hearings.hearingsWith().build());
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.Yes);
     }
 
     @Test
@@ -879,9 +881,9 @@ public class DraftAnOrderControllerTest {
     @Test
     public void testJudgesListsDontMatch() throws Exception {
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.No);
         List<String> errorList = new ArrayList<>();
-        errorList.add("The List does not match RefData");
+        errorList.add(LISTS_DONT_MATCH_ERROR);
         assertEquals(AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build(), draftAnOrderController
                 .populateFl404Fields(authToken, s2sToken, CallbackRequest.builder().build()));
     }

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderControllerTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.prl.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
@@ -879,6 +880,7 @@ public class DraftAnOrderControllerTest {
     }
 
     @Test
+    @Ignore
     public void testJudgesListsDontMatch() throws Exception {
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(true);
         when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.No);

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/DraftAnOrderControllerTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.prl.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
@@ -880,7 +879,6 @@ public class DraftAnOrderControllerTest {
     }
 
     @Test
-    @Ignore
     public void testJudgesListsDontMatch() throws Exception {
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(true);
         when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.No);

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
@@ -211,6 +211,7 @@ public class ManageOrdersControllerTest {
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(expectedCaseData);
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .populatePreviewOrderWhenOrderUploaded(authToken, s2sToken, callbackRequest);
         assertNotNull(callbackResponse);
@@ -250,6 +251,7 @@ public class ManageOrdersControllerTest {
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(expectedCaseData);
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .populatePreviewOrderWhenOrderUploaded(authToken,s2sToken,callbackRequest);
         assertNotNull(callbackResponse);
@@ -284,6 +286,7 @@ public class ManageOrdersControllerTest {
                                        .build())
             .build();
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         Map<String, Object> stringObjectMap = expectedCaseData.toMap(new ObjectMapper());
         Map<String, String> dataFieldMap = new HashMap<>();
         dataFieldMap.put(PrlAppsConstants.TEMPLATE, "templateName");
@@ -342,6 +345,7 @@ public class ManageOrdersControllerTest {
         DocumentLanguage documentLanguage = DocumentLanguage.builder().isGenEng(true).isGenWelsh(true).build();
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(expectedCaseData);
         when(documentLanguageService.docGenerateLang(any(CaseData.class))).thenReturn(documentLanguage);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         uk.gov.hmcts.reform.ccd.client.model.CallbackRequest callbackRequest = uk.gov.hmcts.reform.ccd.client.model
             .CallbackRequest.builder()
@@ -410,6 +414,7 @@ public class ManageOrdersControllerTest {
         when(manageOrderService.getUpdatedCaseData(caseData)).thenReturn(stringObjectMap);
         when(manageOrderService.populateCustomOrderFields(any(CaseData.class))).thenReturn(updatedCaseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         CallbackResponse callbackResponse = manageOrdersController.fetchOrderDetails(authToken, s2sToken,callbackRequest);
         assertNotNull(callbackResponse);
     }
@@ -468,6 +473,7 @@ public class ManageOrdersControllerTest {
         when(manageOrderService.getUpdatedCaseData(any(CaseData.class))).thenReturn(stringObjectMap);
         when(manageOrderService.populateCustomOrderFields(any(CaseData.class))).thenReturn(updatedCaseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         CallbackResponse callbackResponse = manageOrdersController.fetchOrderDetails(authToken,s2sToken,callbackRequest);
         assertEquals("Child 1: TestName\n", callbackResponse.getData().getChildrenList());
         assertEquals(
@@ -536,6 +542,7 @@ public class ManageOrdersControllerTest {
                                                                      .roles(List.of(Roles.JUDGE.getValue())).build());
         when(manageOrderService.populateHearingsDropdown(anyString(), any(CaseData.class))).thenReturn(dynamicList);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .prepopulateFL401CaseDetails("auth-test", s2sToken, callbackRequest);
         assertNotNull(callbackResponse);
@@ -605,6 +612,7 @@ public class ManageOrdersControllerTest {
                                                                      .roles(List.of(Roles.JUDGE.getValue())).build());
         when(manageOrderService.populateHearingsDropdown(anyString(), any(CaseData.class))).thenReturn(dynamicList);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .prepopulateFL401CaseDetails("auth-test", s2sToken, callbackRequest);
         assertNotNull(callbackResponse);
@@ -675,6 +683,7 @@ public class ManageOrdersControllerTest {
                                                                      .roles(List.of(Roles.JUDGE.getValue())).build());
         when(manageOrderService.populateHearingsDropdown(anyString(), any(CaseData.class))).thenReturn(dynamicList);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse response = manageOrdersController.prepopulateFL401CaseDetails("auth-test", s2sToken, callbackRequest);
         assertNotNull(response);
     }
@@ -727,6 +736,7 @@ public class ManageOrdersControllerTest {
         when(manageOrderService.getUpdatedCaseData(any(CaseData.class))).thenReturn(stringObjectMap);
         when(manageOrderService.populateCustomOrderFields(any(CaseData.class))).thenReturn(updatedCaseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         CallbackResponse callbackResponse = manageOrdersController.fetchOrderDetails(authToken,s2sToken,callbackRequest);
         assertEquals("Child 1: TestName\n", callbackResponse.getData().getChildrenList());
         assertEquals(
@@ -807,6 +817,7 @@ public class ManageOrdersControllerTest {
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         when(userService.getUserDetails(Mockito.anyString())).thenReturn(userDetails);
         when(caseSummaryTabService.updateTab(caseData)).thenReturn(summaryTabFields);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.sendEmailNotificationOnClosingOrder(
             authToken,
             s2sToken,
@@ -914,6 +925,7 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.saveOrderDetails(
             authToken,
             s2sToken,
@@ -951,6 +963,7 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.populateHeader(
             callbackRequest, authToken, s2sToken
         );
@@ -1024,6 +1037,7 @@ public class ManageOrdersControllerTest {
             .build();
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(caseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         manageOrdersController.showPreviewOrderWhenOrderCreated(
             authToken,
             s2sToken,
@@ -1131,6 +1145,7 @@ public class ManageOrdersControllerTest {
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(caseData);
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
         when(caseSummaryTabService.updateTab(caseData)).thenReturn(summaryTabFields);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.sendEmailNotificationOnClosingOrder(
             authToken,
             s2sToken,
@@ -1229,6 +1244,7 @@ public class ManageOrdersControllerTest {
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         when(manageOrderService.getOrderToAmendDownloadLink(caseData)).thenReturn(new HashMap<>());
         when(userService.getUserDetails(Mockito.anyString())).thenReturn(userDetails);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.populateOrderToAmendDownloadLink(
             authToken,
             s2sToken,
@@ -1328,6 +1344,7 @@ public class ManageOrdersControllerTest {
             .thenReturn(Map.of("orderCollection", orderDetailsList));
         when(manageOrderService.setChildOptionsIfOrderAboutAllChildrenYes(caseData))
             .thenReturn(caseData);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         uk.gov.hmcts.reform.ccd.client.model.CallbackRequest callbackRequest = uk.gov.hmcts.reform.ccd.client.model
             .CallbackRequest.builder()
             .caseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -1365,6 +1382,7 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.manageOrderMidEvent(
             authToken,
             s2sToken,
@@ -1416,6 +1434,7 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.addUploadOrder(
             authToken,
             s2sToken,
@@ -1467,6 +1486,7 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.addUploadOrder(
             authToken,
             s2sToken,
@@ -1510,6 +1530,7 @@ public class ManageOrdersControllerTest {
             .thenReturn(stringObjectMap);
         when(manageOrderService.setChildOptionsIfOrderAboutAllChildrenYes(caseData))
             .thenReturn(caseData);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         uk.gov.hmcts.reform.ccd.client.model.CallbackRequest callbackRequest = uk.gov.hmcts.reform.ccd.client.model
             .CallbackRequest.builder()
             .caseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -1540,6 +1561,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.populatePreviewOrderWhenOrderUploaded(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1559,6 +1581,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.prepopulateFL401CaseDetails(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1578,6 +1601,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.populateHeader(callbackRequest, authToken, s2sToken);
         }, RuntimeException.class, "Invalid Client");
@@ -1597,6 +1621,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.sendEmailNotificationOnClosingOrder(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1616,6 +1641,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.showPreviewOrderWhenOrderCreated(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1635,6 +1661,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.populateOrderToAmendDownloadLink(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1654,6 +1681,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.addUploadOrder(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1673,6 +1701,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.manageOrderMidEvent(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1692,6 +1721,7 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.serveOrderMidEvent(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1711,9 +1741,20 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.prePopulateJudgeOrLegalAdviser(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
+    }
+
+    @Test
+    public void testJudgesListsDontMatch() throws Exception {
+        Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(false);
+        List<String> errorList = new ArrayList<>();
+        errorList.add("The List does not match RefData");
+        assertEquals(AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build(), manageOrdersController
+                .populatePreviewOrderWhenOrderUploaded(authToken, s2sToken, CallbackRequest.builder().build()));
     }
 
     protected <T extends Throwable> void assertExpectedException(ThrowingRunnable methodExpectedToFail, Class<T> expectedThrowableClass,

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
@@ -170,6 +170,8 @@ public class ManageOrdersControllerTest {
         when(hearingDataService.populateHearingDynamicLists(Mockito.anyString(),Mockito.anyString(),Mockito.any(),Mockito.any()))
             .thenReturn(HearingDataPrePopulatedDynamicLists.builder().build());
 
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
+
         when(hearingDataService.getHearingData(Mockito.any(),Mockito.any(),Mockito.any()))
             .thenReturn(List.of(Element.<HearingData>builder().build()));
 
@@ -211,7 +213,6 @@ public class ManageOrdersControllerTest {
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(expectedCaseData);
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .populatePreviewOrderWhenOrderUploaded(authToken, s2sToken, callbackRequest);
         assertNotNull(callbackResponse);
@@ -251,7 +252,6 @@ public class ManageOrdersControllerTest {
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(expectedCaseData);
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .populatePreviewOrderWhenOrderUploaded(authToken,s2sToken,callbackRequest);
         assertNotNull(callbackResponse);
@@ -286,7 +286,6 @@ public class ManageOrdersControllerTest {
                                        .build())
             .build();
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         Map<String, Object> stringObjectMap = expectedCaseData.toMap(new ObjectMapper());
         Map<String, String> dataFieldMap = new HashMap<>();
         dataFieldMap.put(PrlAppsConstants.TEMPLATE, "templateName");
@@ -345,7 +344,6 @@ public class ManageOrdersControllerTest {
         DocumentLanguage documentLanguage = DocumentLanguage.builder().isGenEng(true).isGenWelsh(true).build();
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(expectedCaseData);
         when(documentLanguageService.docGenerateLang(any(CaseData.class))).thenReturn(documentLanguage);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         uk.gov.hmcts.reform.ccd.client.model.CallbackRequest callbackRequest = uk.gov.hmcts.reform.ccd.client.model
             .CallbackRequest.builder()
@@ -414,7 +412,6 @@ public class ManageOrdersControllerTest {
         when(manageOrderService.getUpdatedCaseData(caseData)).thenReturn(stringObjectMap);
         when(manageOrderService.populateCustomOrderFields(any(CaseData.class))).thenReturn(updatedCaseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         CallbackResponse callbackResponse = manageOrdersController.fetchOrderDetails(authToken, s2sToken,callbackRequest);
         assertNotNull(callbackResponse);
     }
@@ -473,7 +470,6 @@ public class ManageOrdersControllerTest {
         when(manageOrderService.getUpdatedCaseData(any(CaseData.class))).thenReturn(stringObjectMap);
         when(manageOrderService.populateCustomOrderFields(any(CaseData.class))).thenReturn(updatedCaseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         CallbackResponse callbackResponse = manageOrdersController.fetchOrderDetails(authToken,s2sToken,callbackRequest);
         assertEquals("Child 1: TestName\n", callbackResponse.getData().getChildrenList());
         assertEquals(
@@ -542,7 +538,6 @@ public class ManageOrdersControllerTest {
                                                                      .roles(List.of(Roles.JUDGE.getValue())).build());
         when(manageOrderService.populateHearingsDropdown(anyString(), any(CaseData.class))).thenReturn(dynamicList);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .prepopulateFL401CaseDetails("auth-test", s2sToken, callbackRequest);
         assertNotNull(callbackResponse);
@@ -612,7 +607,6 @@ public class ManageOrdersControllerTest {
                                                                      .roles(List.of(Roles.JUDGE.getValue())).build());
         when(manageOrderService.populateHearingsDropdown(anyString(), any(CaseData.class))).thenReturn(dynamicList);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse callbackResponse = manageOrdersController
             .prepopulateFL401CaseDetails("auth-test", s2sToken, callbackRequest);
         assertNotNull(callbackResponse);
@@ -683,7 +677,6 @@ public class ManageOrdersControllerTest {
                                                                      .roles(List.of(Roles.JUDGE.getValue())).build());
         when(manageOrderService.populateHearingsDropdown(anyString(), any(CaseData.class))).thenReturn(dynamicList);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse response = manageOrdersController.prepopulateFL401CaseDetails("auth-test", s2sToken, callbackRequest);
         assertNotNull(response);
     }
@@ -736,7 +729,6 @@ public class ManageOrdersControllerTest {
         when(manageOrderService.getUpdatedCaseData(any(CaseData.class))).thenReturn(stringObjectMap);
         when(manageOrderService.populateCustomOrderFields(any(CaseData.class))).thenReturn(updatedCaseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         CallbackResponse callbackResponse = manageOrdersController.fetchOrderDetails(authToken,s2sToken,callbackRequest);
         assertEquals("Child 1: TestName\n", callbackResponse.getData().getChildrenList());
         assertEquals(
@@ -817,7 +809,6 @@ public class ManageOrdersControllerTest {
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         when(userService.getUserDetails(Mockito.anyString())).thenReturn(userDetails);
         when(caseSummaryTabService.updateTab(caseData)).thenReturn(summaryTabFields);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.sendEmailNotificationOnClosingOrder(
             authToken,
             s2sToken,
@@ -925,7 +916,6 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.saveOrderDetails(
             authToken,
             s2sToken,
@@ -963,7 +953,6 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.populateHeader(
             callbackRequest, authToken, s2sToken
         );
@@ -1144,7 +1133,6 @@ public class ManageOrdersControllerTest {
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(caseData);
         when(objectMapper.convertValue(caseData, CaseData.class)).thenReturn(caseData);
         when(caseSummaryTabService.updateTab(caseData)).thenReturn(summaryTabFields);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.sendEmailNotificationOnClosingOrder(
             authToken,
             s2sToken,
@@ -1243,7 +1231,6 @@ public class ManageOrdersControllerTest {
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
         when(manageOrderService.getOrderToAmendDownloadLink(caseData)).thenReturn(new HashMap<>());
         when(userService.getUserDetails(Mockito.anyString())).thenReturn(userDetails);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.populateOrderToAmendDownloadLink(
             authToken,
             s2sToken,
@@ -1343,7 +1330,6 @@ public class ManageOrdersControllerTest {
             .thenReturn(Map.of("orderCollection", orderDetailsList));
         when(manageOrderService.setChildOptionsIfOrderAboutAllChildrenYes(caseData))
             .thenReturn(caseData);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         uk.gov.hmcts.reform.ccd.client.model.CallbackRequest callbackRequest = uk.gov.hmcts.reform.ccd.client.model
             .CallbackRequest.builder()
             .caseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -1381,7 +1367,6 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.manageOrderMidEvent(
             authToken,
             s2sToken,
@@ -1433,7 +1418,6 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.addUploadOrder(
             authToken,
             s2sToken,
@@ -1485,7 +1469,6 @@ public class ManageOrdersControllerTest {
                              .build())
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         AboutToStartOrSubmitCallbackResponse aboutToStartOrSubmitCallbackResponse = manageOrdersController.addUploadOrder(
             authToken,
             s2sToken,
@@ -1529,7 +1512,6 @@ public class ManageOrdersControllerTest {
             .thenReturn(stringObjectMap);
         when(manageOrderService.setChildOptionsIfOrderAboutAllChildrenYes(caseData))
             .thenReturn(caseData);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         uk.gov.hmcts.reform.ccd.client.model.CallbackRequest callbackRequest = uk.gov.hmcts.reform.ccd.client.model
             .CallbackRequest.builder()
             .caseDetails(uk.gov.hmcts.reform.ccd.client.model.CaseDetails.builder()
@@ -1560,7 +1542,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.populatePreviewOrderWhenOrderUploaded(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1580,7 +1561,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.prepopulateFL401CaseDetails(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1600,7 +1580,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.populateHeader(callbackRequest, authToken, s2sToken);
         }, RuntimeException.class, "Invalid Client");
@@ -1620,7 +1599,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.sendEmailNotificationOnClosingOrder(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1640,7 +1618,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.showPreviewOrderWhenOrderCreated(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1660,7 +1637,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.populateOrderToAmendDownloadLink(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1680,7 +1656,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.addUploadOrder(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1700,7 +1675,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.manageOrderMidEvent(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1720,7 +1694,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.serveOrderMidEvent(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");
@@ -1740,7 +1713,6 @@ public class ManageOrdersControllerTest {
             .build();
 
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(false);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         assertExpectedException(() -> {
             manageOrdersController.prePopulateJudgeOrLegalAdviser(authToken, s2sToken, callbackRequest);
         }, RuntimeException.class, "Invalid Client");

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
@@ -1037,7 +1037,6 @@ public class ManageOrdersControllerTest {
             .build();
         when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(caseData);
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
         manageOrdersController.showPreviewOrderWhenOrderCreated(
             authToken,
             s2sToken,

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
@@ -74,6 +74,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTS_DONT_MATCH_ERROR;
 import static uk.gov.hmcts.reform.prl.enums.Gender.female;
 import static uk.gov.hmcts.reform.prl.enums.OrderTypeEnum.childArrangementsOrder;
 import static uk.gov.hmcts.reform.prl.enums.RelationshipsEnum.father;
@@ -170,7 +171,7 @@ public class ManageOrdersControllerTest {
         when(hearingDataService.populateHearingDynamicLists(Mockito.anyString(),Mockito.anyString(),Mockito.any(),Mockito.any()))
             .thenReturn(HearingDataPrePopulatedDynamicLists.builder().build());
 
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(true);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.Yes);
 
         when(hearingDataService.getHearingData(Mockito.any(),Mockito.any(),Mockito.any()))
             .thenReturn(List.of(Element.<HearingData>builder().build()));
@@ -1721,9 +1722,9 @@ public class ManageOrdersControllerTest {
     @Test
     public void testJudgesListsDontMatch() throws Exception {
         Mockito.when(authorisationService.isAuthorized(authToken,s2sToken)).thenReturn(true);
-        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(false);
+        when(manageOrderService.checkJudgeOrMagistrateList(Mockito.any())).thenReturn(YesOrNo.No);
         List<String> errorList = new ArrayList<>();
-        errorList.add("The List does not match RefData");
+        errorList.add(LISTS_DONT_MATCH_ERROR);
         assertEquals(AboutToStartOrSubmitCallbackResponse.builder().errors(errorList).build(), manageOrdersController
                 .populatePreviewOrderWhenOrderUploaded(authToken, s2sToken, CallbackRequest.builder().build()));
     }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/ManageOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/ManageOrderServiceTest.java
@@ -4,6 +4,7 @@ package uk.gov.hmcts.reform.prl.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -3288,6 +3289,7 @@ public class ManageOrderServiceTest {
     }
 
     @Test
+    @Ignore
     public void testCheckJudgeOrMagistrateListReturnsTrue() {
         List<DynamicListElement> dynamicListElementsList = new ArrayList<>();
         dynamicListElementsList.add(DynamicListElement.builder().label("Her Honour Judge").build());

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/ManageOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/ManageOrderServiceTest.java
@@ -4,7 +4,6 @@ package uk.gov.hmcts.reform.prl.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -3289,7 +3288,6 @@ public class ManageOrderServiceTest {
     }
 
     @Test
-    @Ignore
     public void testCheckJudgeOrMagistrateListReturnsTrue() {
         List<DynamicListElement> dynamicListElementsList = new ArrayList<>();
         dynamicListElementsList.add(DynamicListElement.builder().label("Her Honour Judge").build());

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/ManageOrderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/ManageOrderServiceTest.java
@@ -3284,8 +3284,8 @@ public class ManageOrderServiceTest {
                         .builder()
                         .listItems(dynamicListElementsList)
                         .build());
-        boolean bool = manageOrderService.checkJudgeOrMagistrateList("test");
-        assertEquals(false, bool);
+        YesOrNo bool = manageOrderService.checkJudgeOrMagistrateList("test");
+        assertEquals(YesOrNo.No, bool);
     }
 
     @Test
@@ -3299,8 +3299,8 @@ public class ManageOrderServiceTest {
                         .builder()
                         .listItems(dynamicListElementsList)
                         .build());
-        boolean bool = manageOrderService.checkJudgeOrMagistrateList("test");
-        assertEquals(true, bool);
+        YesOrNo bool = manageOrderService.checkJudgeOrMagistrateList("test");
+        assertEquals(YesOrNo.Yes, bool);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###


https://tools.hmcts.net/jira/browse/PRL-4261

### Change description ###

in the manage order and draft an order flow, the types of judges are a static list. However, this data is stored in refdata. This ticket will pull the data for the types of judges from refdata making it dynamic.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
