### PR TITLE
FPET-818: CA Respondent previous address details fix

### DIFF
--- a/charts/prl-cos/values.preview.template.yaml
+++ b/charts/prl-cos/values.preview.template.yaml
@@ -37,11 +37,11 @@ java:
     IDAM_CLIENT_REDIRECT_URI: https://prl-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    CORE_CASE_DATA_API_URL: http://prl-ccd-definitions-pr-1767-ccd-data-store-api
+    CORE_CASE_DATA_API_URL: http://prl-ccd-definitions-pr-1797-ccd-data-store-api
     AUTH_IDAM_CLIENT_BASEURL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     DOCMOSIS_SERVICE_BASE_URL: https://docmosis.aat.platform.hmcts.net
-    CCD_CASE_DOCS_AM_API: http://prl-ccd-definitions-pr-1767-cdam
+    CCD_CASE_DOCS_AM_API: http://prl-ccd-definitions-pr-1797-cdam
     XUI_URL: https://manage-case.{{ .Values.global.environment }}.platform.hmcts.net/cases/case-details
     REFORM_SERVICE_NAME: prl_cos_api
     AUTH_PROVIDER_SERVICE_CLIENT_MICROSERVICE: prl_cos_api
@@ -53,9 +53,9 @@ java:
     FACT_API: http://fact-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     LOCATION_REF_API: http://rd-location-ref-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     RD_PROFESSIONAL_API: http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    ACA_SERVICE_API_BASEURL: http://prl-ccd-definitions-pr-1767-aac-manage-case-assignment
+    ACA_SERVICE_API_BASEURL: http://prl-ccd-definitions-pr-1797-aac-manage-case-assignment
     CITIZEN_URL: https://privatelaw.{{ .Values.global.environment }}.platform.hmcts.net
-    BUNDLE_URL: http://prl-ccd-definitions-pr-1767-em-ccdorc
+    BUNDLE_URL: http://prl-ccd-definitions-pr-1797-em-ccdorc
     HEARING_API_BASEURL : http://fis-hmc-api-aat.service.core-compute-aat.internal
     REFDATA_API_URL: http://rd-commondata-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     JUDICIAL_USERS_API: http://rd-judicial-api-aat.service.core-compute-aat.internal

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
@@ -60,8 +60,10 @@ public class UpdatePartyDetailsService {
 
     public Map<String, Object> updateApplicantRespondentAndChildData(CallbackRequest callbackRequest) {
         Map<String, Object> updatedCaseData = callbackRequest.getCaseDetails().getData();
+        log.info("Updated case data: " + updatedCaseData);
 
         CaseData caseData = objectMapper.convertValue(updatedCaseData, CaseData.class);
+        log.info("Respondent details: " + caseData.getRespondents());
 
         CaseData caseDataTemp = confidentialDetailsMapper.mapConfidentialData(caseData, false);
         updatedCaseData.put(RESPONDENT_CONFIDENTIAL_DETAILS, caseDataTemp.getRespondentConfidentialDetails());
@@ -117,6 +119,7 @@ public class UpdatePartyDetailsService {
             }
         }
         cleanUpCaseDataBasedOnYesNoSelection(updatedCaseData, caseData);
+        log.info("Respondent details after clean up: " + updatedCaseData.get(RESPONDENTS));
         return updatedCaseData;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
@@ -181,7 +181,7 @@ public class UpdatePartyDetailsService {
             .address(YesOrNo.Yes.equals(partyDetails.getIsCurrentAddressKnown()) ? partyDetails.getAddress() : null)
             .isAddressConfidential(YesOrNo.Yes.equals(partyDetails.getIsCurrentAddressKnown())
                                        ? partyDetails.getIsAddressConfidential() : null)
-            .addressLivedLessThan5YearsDetails(YesOrNo.Yes.equals(partyDetails.getIsAtAddressLessThan5Years())
+            .addressLivedLessThan5YearsDetails(YesOrNo.Yes.equals(partyDetails.getIsAtAddressLessThan5YearsWithDontKnow())
                                                    ? partyDetails.getAddressLivedLessThan5YearsDetails() : null)
             .email(YesOrNo.Yes.equals(partyDetails.getCanYouProvideEmailAddress()) ? partyDetails.getEmail() : null)
             .isEmailAddressConfidential(YesOrNo.Yes.equals(partyDetails.getCanYouProvideEmailAddress())

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
@@ -181,7 +181,7 @@ public class UpdatePartyDetailsService {
             .address(YesOrNo.Yes.equals(partyDetails.getIsCurrentAddressKnown()) ? partyDetails.getAddress() : null)
             .isAddressConfidential(YesOrNo.Yes.equals(partyDetails.getIsCurrentAddressKnown())
                                        ? partyDetails.getIsAddressConfidential() : null)
-            .addressLivedLessThan5YearsDetails(YesOrNo.Yes.equals(partyDetails.getIsAtAddressLessThan5YearsWithDontKnow())
+            .addressLivedLessThan5YearsDetails(YesNoDontKnow.yes.equals(partyDetails.getIsAtAddressLessThan5YearsWithDontKnow())
                                                    ? partyDetails.getAddressLivedLessThan5YearsDetails() : null)
             .email(YesOrNo.Yes.equals(partyDetails.getCanYouProvideEmailAddress()) ? partyDetails.getEmail() : null)
             .isEmailAddressConfidential(YesOrNo.Yes.equals(partyDetails.getCanYouProvideEmailAddress())

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
@@ -60,10 +60,8 @@ public class UpdatePartyDetailsService {
 
     public Map<String, Object> updateApplicantRespondentAndChildData(CallbackRequest callbackRequest) {
         Map<String, Object> updatedCaseData = callbackRequest.getCaseDetails().getData();
-        log.info("Updated case data: " + updatedCaseData);
 
         CaseData caseData = objectMapper.convertValue(updatedCaseData, CaseData.class);
-        log.info("Respondent details: " + caseData.getRespondents());
 
         CaseData caseDataTemp = confidentialDetailsMapper.mapConfidentialData(caseData, false);
         updatedCaseData.put(RESPONDENT_CONFIDENTIAL_DETAILS, caseDataTemp.getRespondentConfidentialDetails());
@@ -119,7 +117,6 @@ public class UpdatePartyDetailsService {
             }
         }
         cleanUpCaseDataBasedOnYesNoSelection(updatedCaseData, caseData);
-        log.info("Respondent details after clean up: " + updatedCaseData.get(RESPONDENTS));
         return updatedCaseData;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsServiceTest.java
@@ -85,6 +85,7 @@ public class UpdatePartyDetailsServiceTest {
             .isAddressConfidential(YesOrNo.No)
             .isPhoneNumberConfidential(YesOrNo.No)
             .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .isAtAddressLessThan5YearsWithDontKnow(YesNoDontKnow.yes)
             .build();
 
         Element<PartyDetails> wrappedRespondent1 = Element.<PartyDetails>builder().value(respondent).build();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPET-818


### Change description ###
Fixes values entered for "Provide details of all previous addresses" not being stored when solicitor is adding respondent details to a CA case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
