### PR TITLE
citizen-response-no-longer-allows-multiple-submits

### DIFF
--- a/charts/prl-cos/values.preview.template.yaml
+++ b/charts/prl-cos/values.preview.template.yaml
@@ -39,10 +39,10 @@ java:
     IDAM_CLIENT_REDIRECT_URI: https://prl-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    AM_ROLE_ASSIGNMENT_API_URL: http://prl-ccd-definitions-pr-1921-am-role-assignment-service
-    CORE_CASE_DATA_API_URL: http://prl-ccd-definitions-pr-1921-ccd-data-store-api
-    CCD_CASE_DOCS_AM_API: http://prl-ccd-definitions-pr-1921-cdam
-    ACA_SERVICE_API_BASEURL: http://prl-ccd-definitions-pr-1921-aac-manage-case-assignment
+    AM_ROLE_ASSIGNMENT_API_URL: http://prl-ccd-definitions-pr-1967-am-role-assignment-service
+    CORE_CASE_DATA_API_URL: http://prl-ccd-definitions-pr-1967-ccd-data-store-api
+    CCD_CASE_DOCS_AM_API: http://prl-ccd-definitions-pr-1967-cdam
+    ACA_SERVICE_API_BASEURL: http://prl-ccd-definitions-pr-1967-aac-manage-case-assignment
     BUNDLE_URL: http://prl-ccd-definitions-pr-1921-em-ccdorc
     AUTH_IDAM_CLIENT_BASEURL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseApplicationResponseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseApplicationResponseControllerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -354,6 +355,7 @@ public class CaseApplicationResponseControllerTest {
         CaseData caseData1 = caseApplicationResponseController
             .generateC7FinalDocument(caseId, partyId, authToken, servAuthToken);
         assertNotNull(caseData1);
+        assertEquals(YesOrNo.Yes, caseData1.getRespondents().get(0).getValue().getResponse().getC7ResponseSubmitted());
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

Currently, the citizen journey allows the respondent to submit the response multiple times. This is due to changes made in the cos when a response is submitted. This change will fix this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
