### PR TITLE
PRL-5941 - Added changes to group citizen documents into applicant, respondent & other documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/models/dto/citizen/CitizenDocumentsManagement.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/models/dto/citizen/CitizenDocumentsManagement.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.prl.models.dto.citizen;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Set;
 
 @Data
 @Builder(toBuilder = true)
@@ -16,8 +18,17 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class CitizenDocumentsManagement {
 
-    @JsonProperty("citizenDocuments")
+    @JsonIgnore
     public List<CitizenDocuments> citizenDocuments;
+
+    @JsonProperty("applicantDocuments")
+    public List<CitizenDocuments> applicantDocuments;
+
+    @JsonProperty("respondentDocuments")
+    public List<CitizenDocuments> respondentDocuments;
+
+    @JsonProperty("otherDocuments")
+    public List<CitizenDocuments> otherDocuments;
 
     @JsonProperty("citizenOrders")
     public List<CitizenDocuments> citizenOrders;
@@ -30,8 +41,8 @@ public class CitizenDocumentsManagement {
      */
     private List<CitizenNotification> citizenNotifications;
 
-    public static final List<String> unReturnedCategoriesForUI =
-        List.of(
+    public static final Set<String> unReturnedCategoriesForUI =
+        Set.of(
             "section37Report",
             "16aRiskAssessment",
             "sec37Report",
@@ -46,5 +57,17 @@ public class CitizenDocumentsManagement {
             "specialMeasures",
             "noticeOfHearing",
             "caseSummary"
+        );
+
+    public static final Set<String> otherDocumentsCategoriesForUI =
+        Set.of(
+            "magistratesFactsAndReasons",
+            "otherWitnessStatements",
+            "localAuthorityOtherDoc",
+            "emailsToCourtToRequestHearingsAdjourned",
+            "witnessAvailability",
+            "privacyNotice",
+            "anyOtherDoc",
+            "courtBundle"
         );
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/citizen/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/citizen/CaseServiceTest.java
@@ -9,6 +9,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
@@ -100,6 +102,7 @@ public class CaseServiceTest {
     public static final String eventId = "1234567891234567";
 
     public static final String accessCode = "123456";
+    private static final Logger log = LoggerFactory.getLogger(CaseServiceTest.class);
 
     @InjectMocks
     private CaseService caseService;
@@ -595,8 +598,9 @@ public class CaseServiceTest {
 
         //Assert
         assertNotNull(citizenDocumentsManagement);
-        assertFalse(citizenDocumentsManagement.getCitizenDocuments().isEmpty());
-        assertEquals(7, citizenDocumentsManagement.getCitizenDocuments().size());
+        assertFalse(citizenDocumentsManagement.getApplicantDocuments().isEmpty());
+        assertFalse(citizenDocumentsManagement.getOtherDocuments().isEmpty());
+        assertEquals(6, citizenDocumentsManagement.getApplicantDocuments().size());
     }
 
     @Test
@@ -615,7 +619,9 @@ public class CaseServiceTest {
 
         //Assert
         assertNotNull(citizenDocumentsManagement);
-        assertTrue(citizenDocumentsManagement.getCitizenDocuments().isEmpty());
+        assertTrue(citizenDocumentsManagement.getApplicantDocuments().isEmpty());
+        assertTrue(citizenDocumentsManagement.getRespondentDocuments().isEmpty());
+        assertTrue(citizenDocumentsManagement.getOtherDocuments().isEmpty());
     }
 
     @Test
@@ -651,7 +657,10 @@ public class CaseServiceTest {
 
         //Assert
         assertNotNull(citizenDocumentsManagement);
-        assertTrue(citizenDocumentsManagement.getCitizenDocuments().isEmpty());
+        log.info("{}", citizenDocumentsManagement);
+        assertTrue(citizenDocumentsManagement.getApplicantDocuments().isEmpty());
+        assertTrue(citizenDocumentsManagement.getRespondentDocuments().isEmpty());
+        assertTrue(citizenDocumentsManagement.getOtherDocuments().isEmpty());
     }
 
     @Test


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRL-5941


### Change description ###
Added changes
1. Group citizen documents into party specific applicant, respondent & other documents.
2. Add transcripts of judgements to citizen orders


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
