### PR TITLE
SNI-6902: Show respondent solicitor's name for statement of truth

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/models/dto/ccd/BaseCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/models/dto/ccd/BaseCaseData.java
@@ -95,4 +95,7 @@ public class BaseCaseData {
 
     @JsonUnwrapped
     private String isNonWorkAllocationEnabledCourtSelected;
+
+    @JsonProperty("respondentSolicitorName")
+    private String respondentSolicitorName;
 }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/c100respondentsolicitor/C100RespondentSolicitorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/c100respondentsolicitor/C100RespondentSolicitorService.java
@@ -844,6 +844,10 @@ public class C100RespondentSolicitorService {
                         && YesOrNo.Yes.equals(respondingParty.getValue().getUser().getSolicitorRepresented())) {
                     boolean isC1aApplicable = caseData.getC1ADocument() != null;
                     mandatoryFinished = responseSubmitChecker.isFinished(respondingParty.getValue(), isC1aApplicable);
+                    caseDataUpdated.put(
+                        "respondentSolicitorName",
+                        respondingParty.getValue().getRepresentativeFirstName() + " " + respondingParty.getValue().getRepresentativeLastName()
+                    );
                 }
             }
         }
@@ -856,6 +860,7 @@ public class C100RespondentSolicitorService {
 
     public Map<String, Object> submitC7ResponseForActiveRespondent(String authorisation, CallbackRequest callbackRequest) throws Exception {
         Map<String, Object> updatedCaseData = callbackRequest.getCaseDetails().getData();
+        updatedCaseData.remove("respondentSolicitorName");
         List<QuarantineLegalDoc> quarantineLegalDocList = new ArrayList<>();
         UserDetails userDetails = userService.getUserDetails(authorisation);
         final String[] surname = {null};


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SNI-6902


### Change description ###
Fixes issue where applicant solicitor name shows instead of respondent solicitor's for the statement of truth when respondent solicitor is submitting the response.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
