### PR TITLE
FPVTL-129: change seal logic so it uses the case region instead of the language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/main/resources/application.yaml
 /.aat-env
 /bin/ccd-config-PRL-local.xlsx
 /bin/
+/.mirrord/mirrord.json

--- a/charts/prl-cos/values.preview.template.yaml
+++ b/charts/prl-cos/values.preview.template.yaml
@@ -63,7 +63,7 @@ java:
   environment:
     PRD_API_BASEURL: http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     PAY_URL: http://payment-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    PAY_CALLBACK_URL: https://prl-cos-pr-3092.preview.platform.hmcts.net/service-request-update
+    PAY_CALLBACK_URL: https://prl-cos-pr-3102.preview.platform.hmcts.net/service-request-update
     FEE_URL: http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     RUNS_LOCALLY: false
     IDAM_CLIENT_ID: prl-cos-api

--- a/src/main/java/uk/gov/hmcts/reform/prl/constants/PrlAppsConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/constants/PrlAppsConstants.java
@@ -912,10 +912,10 @@ public class PrlAppsConstants {
         + "If Cafcass are involved in the case, they will provide the court with a safeguarding letter. ";
     public static final String ALL_RESPONDENTS = "All respondents";
     public static final String TEST_UUID = "00000000-0000-0000-0000-000000000000";
-    public static final String ADD_PEOPLE_TO_THE_CASE = "Add people to the case / Ychwanegu pobl i’r achos"; 
-    public static final String ONLY_COMPLETE_IF_RELEVANT = "Only complete if relevant / Llenwch yr adran hon dim ond os yw’n berthnasol"; 
+    public static final String ADD_PEOPLE_TO_THE_CASE = "Add people to the case / Ychwanegu pobl i’r achos";
+    public static final String ONLY_COMPLETE_IF_RELEVANT = "Only complete if relevant / Llenwch yr adran hon dim ond os yw’n berthnasol";
     public static final String  ADD_APPLICATION_DETAILS = "Add application details / Ychwanegu manylion y cais";
-    public static final String  ADD_ADDITIONAL_INFORMATION = "Add additional information / Ychwanegu gwybodaeth ychwanegol"; 
+    public static final String  ADD_ADDITIONAL_INFORMATION = "Add additional information / Ychwanegu gwybodaeth ychwanegol";
 
     public static final String  TASK_LIST_VERSION_V2 = "v2";
     public static final String  TASK_LIST_VERSION_V3 = "v3";
@@ -1128,5 +1128,6 @@ public class PrlAppsConstants {
     public static final String PLEASE_SELECT_ONE_OPTION = "Please select at least one options from below";
     public static final String PLEASE_SELECT_ONE_OPTION_WELSH = "Dewiswch o leiaf un opsiwn o’r opsiynau isod";
 
+    public static final String REGION_WALES = "7";
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/DocumentSealingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/DocumentSealingService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import static org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode.APPEND;
 import static org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject.createFromByteArray;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DUMMY;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.REGION_WALES;
 import static uk.gov.hmcts.reform.prl.utils.ResourceReader.readBytes;
 
 @Service
@@ -60,7 +61,7 @@ public class DocumentSealingService {
             s2sToken
         );
 
-        byte[] seal = readBytes(getCourtSealImage(caseData.getCourtSeal()));
+        byte[] seal = readBytes(getCourtSealImage(caseData.getCaseManagementLocation().getRegion()));
         byte[] sealedDocument = addSealToDocument(downloadedPdf, seal);
 
         Map<String, Object> tempCaseDetails = new HashMap<>();
@@ -114,19 +115,13 @@ public class DocumentSealingService {
         return Math.round(POINTS_PER_MM * mm);
     }
 
-    private static String getCourtSealImage(String seal) {
+    private static String getCourtSealImage(String region) {
         String courtSeal = "";
-        switch (seal) {
-            case USER_IMAGE_COURT_SEAL_BILINGUAL:
-                courtSeal = COURT_SEAL_BILINGUAL;
-                break;
-            case USER_IMAGE_COURT_SEAL:
-                courtSeal = COURT_SEAL;
-                break;
-            default:
-                break;
+        if (region.equals(REGION_WALES)) {
+            courtSeal = COURT_SEAL_BILINGUAL;
+        } else {
+            courtSeal = COURT_SEAL;
         }
-
         return courtSeal;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/DocumentSealingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/DocumentSealingServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.prl.clients.DgsApiClient;
+import uk.gov.hmcts.reform.prl.models.complextypes.CaseManagementLocation;
 import uk.gov.hmcts.reform.prl.models.documents.Document;
 import uk.gov.hmcts.reform.prl.models.dto.GenerateDocumentRequest;
 import uk.gov.hmcts.reform.prl.models.dto.GeneratedDocumentInfo;
@@ -80,7 +81,16 @@ public class DocumentSealingServiceTest {
         when(dgsApiClient.convertDocToPdf(anyString(), anyString(), any())).thenReturn(documentInfo);
         MockedStatic<ResourceReader> mockResourceReader = mockStatic(ResourceReader.class);
         mockResourceReader.when(() -> ResourceReader.readBytes("/familycourtseal.png")).thenReturn(sealBinaries);
-        CaseData caseData = CaseData.builder().courtSeal("[userImage:familycourtseal.png]").build();
+        CaseData caseData = CaseData.builder().courtSeal("[userImage:familycourtseal.png]")
+            .caseManagementLocation(CaseManagementLocation.builder()
+                                        .region("2")
+                                        .regionId(null)
+                                        .regionName("Midlands")
+                                        .baseLocation("123456789")
+                                        .baseLocationId(null)
+                                        .baseLocationName("Birmingham")
+                                        .build())
+            .build();
 
         final Document actualSealedDocumentReference = documentSealingService
             .sealDocument(inputDocument, caseData, "testAuth");
@@ -120,7 +130,16 @@ public class DocumentSealingServiceTest {
         mockResourceReader.when(() -> ResourceReader.readBytes("/familycourtseal-bilingual.png")).thenReturn(
             sealBinaries);
 
-        CaseData caseData = CaseData.builder().courtSeal("[userImage:familycourtseal-bilingual.png]").build();
+        CaseData caseData = CaseData.builder().courtSeal("[userImage:familycourtseal-bilingual.png]")
+            .caseManagementLocation(CaseManagementLocation.builder()
+                                        .region("7")
+                                        .regionId(null)
+                                        .regionName("Wales")
+                                        .baseLocation("234946")
+                                        .baseLocationId(null)
+                                        .baseLocationName("Swansea")
+                                        .build())
+            .build();
 
         final Document actualSealedDocumentReference = documentSealingService
             .sealDocument(inputDocument, caseData, "testAuth");
@@ -151,7 +170,16 @@ public class DocumentSealingServiceTest {
         mockResourceReader.when(() -> ResourceReader.readBytes("/familycourtseal-bilingual.png")).thenReturn(
             sealBinaries);
 
-        CaseData caseData = CaseData.builder().courtSeal("[userImage:familycourtseal-bilingual.png]").build();
+        CaseData caseData = CaseData.builder().courtSeal("[userImage:familycourtseal-bilingual.png]")
+            .caseManagementLocation(CaseManagementLocation.builder()
+                                        .region("7")
+                                        .regionId(null)
+                                        .regionName("Wales")
+                                        .baseLocation("234946")
+                                        .baseLocationId(null)
+                                        .baseLocationName("Swansea")
+                                        .build())
+            .build();
         Document inputDocument = Document.builder()
             .documentUrl("/test").documentBinaryUrl("/test/binary").documentFileName("test.pdf").build();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FPVTL-129](https://tools.hmcts.net/jira/browse/FPVTL-129)


### Change description ###
Change seal logic so it uses the region in  caseManagementLocation, where the case is based, instead of the language
Update unit tests to reflect this change in logic.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
