### PR TITLE
Upgrade dependencies to fix CVE-2024-45772 & CVE-2025-25193

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'info.solidsoft.pitest' version '1.15.0'
   id 'io.spring.dependency-management' version '1.1.7'
   id 'jacoco'
-  id 'org.owasp.dependencycheck' version '9.2.0'
+  id 'org.owasp.dependencycheck' version '11.0.0'
   id 'org.sonarqube' version '5.1.0.4882'
   id 'org.springframework.boot' version '3.3.5'
   id 'au.com.dius.pact' version '4.2.6'

--- a/build.gradle
+++ b/build.gradle
@@ -396,7 +396,6 @@ dependencies {
   implementation(group: 'org.springframework.security', name: 'spring-security-rsa', version: versions.springSecurityRsa)
   implementation(group: 'org.springframework.security', name: 'spring-security-crypto', version: versions.springSecurityCrypto)
   implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.118.Final'
-
   constraints{
     implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -383,6 +383,11 @@ dependencies {
   implementation(group: 'org.springframework.security', name: 'spring-security-rsa', version: versions.springSecurityRsa)
   implementation(group: 'org.springframework.security', name: 'spring-security-crypto', version: versions.springSecurityCrypto)
   implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.118.Final'
+  // Fixes for CVE-2025-25193
+  implementation group: 'io.netty', name: 'netty-transport-classes-epoll', version: '4.1.118.Final'
+  implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: '4.1.118.Final'
+  // Fix for CVE-2024-45772
+  implementation group: 'org.apache.lucene', name: 'lucene-core', version: '9.12.0'
   constraints{
     implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ configurations.configureEach {
     if (requested.group == 'org.apache.lucene' && requested.name != 'lucene-analyzers-common') {
       useVersion '9.12.0'
     }
-    if (requested.group == 'io.netty' && requested.name == 'netty-transport-classes-epoll' || 'netty-transport-native-unix-common') {
+    if (requested.group == 'io.netty' && (requested.name == 'netty-transport-classes-epoll' ||  requested.name == 'netty-transport-native-unix-common')) {
       useVersion '4.1.118.Final'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ def versions = [
   ccdCaseDocumentAmClient      : '1.7.3',
   pdfbox                       : '2.0.33',
   springFramework              : '6.1.14',
-  luceneVersion                : '9.12.0'
 ]
 
 allprojects {
@@ -298,6 +297,16 @@ configurations.configureEach {
   }
 }
 
+// Fixes for CVE-2024-45772
+configurations.configureEach {
+  resolutionStrategy.eachDependency {
+    // lucene-analyzers-common is not a vulnerable dependency and doesn't have a version 9.12.0
+    if (requested.group == 'org.apache.lucene' && requested.name != 'lucene-analyzers-common') {
+      useVersion '9.12.0'
+    }
+  }
+}
+
 dependencies {
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
   implementation group: 'org.springframework', name: 'spring-context-support', version: versions.springFramework
@@ -387,20 +396,6 @@ dependencies {
   // Fixes for CVE-2025-25193
   implementation group: 'io.netty', name: 'netty-transport-classes-epoll', version: '4.1.118.Final'
   implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: '4.1.118.Final'
-
-  // Fixes for CVE-2024-45772
-  implementation group: 'org.apache.lucene', name: 'lucene-analysis-common', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-backward-codecs', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-core', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-grouping', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-highlighter', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-join', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-memory', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-misc', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-queries', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-queryparser', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-sandbox', version: versions.luceneVersion
-  implementation group: 'org.apache.lucene', name: 'lucene-suggest', version: versions.luceneVersion
 
   constraints{
     implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,8 @@ def versions = [
   unirest                      : '1.4.9',
   ccdCaseDocumentAmClient      : '1.7.3',
   pdfbox                       : '2.0.33',
-  springFramework    : '6.1.14'
+  springFramework              : '6.1.14',
+  luceneVersion                : '9.12.0'
 ]
 
 allprojects {
@@ -386,8 +387,21 @@ dependencies {
   // Fixes for CVE-2025-25193
   implementation group: 'io.netty', name: 'netty-transport-classes-epoll', version: '4.1.118.Final'
   implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: '4.1.118.Final'
-  // Fix for CVE-2024-45772
-  implementation group: 'org.apache.lucene', name: 'lucene-core', version: '9.12.0'
+
+  // Fixes for CVE-2024-45772
+  implementation group: 'org.apache.lucene', name: 'lucene-analysis-common', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-backward-codecs', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-core', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-grouping', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-highlighter', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-join', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-memory', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-misc', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-queries', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-queryparser', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-sandbox', version: versions.luceneVersion
+  implementation group: 'org.apache.lucene', name: 'lucene-suggest', version: versions.luceneVersion
+
   constraints{
     implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -297,12 +297,15 @@ configurations.configureEach {
   }
 }
 
-// Fixes for CVE-2024-45772
+// Fixes for CVE-2024-45772 & CVE-2025-25193
 configurations.configureEach {
   resolutionStrategy.eachDependency {
     // lucene-analyzers-common is not a vulnerable dependency and doesn't have a version 9.12.0
     if (requested.group == 'org.apache.lucene' && requested.name != 'lucene-analyzers-common') {
       useVersion '9.12.0'
+    }
+    if (requested.group == 'io.netty' && requested.name == 'netty-transport-classes-epoll' || 'netty-transport-native-unix-common') {
+      useVersion '4.1.118.Final'
     }
   }
 }
@@ -393,9 +396,6 @@ dependencies {
   implementation(group: 'org.springframework.security', name: 'spring-security-rsa', version: versions.springSecurityRsa)
   implementation(group: 'org.springframework.security', name: 'spring-security-crypto', version: versions.springSecurityCrypto)
   implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.118.Final'
-  // Fixes for CVE-2025-25193
-  implementation group: 'io.netty', name: 'netty-transport-classes-epoll', version: '4.1.118.Final'
-  implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: '4.1.118.Final'
 
   constraints{
     implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'


### PR DESCRIPTION
### Change description ###

- Added dependencies for specific packages that are transient dependencies to use a non-vulnerable versions
- lucene dependencies was coming from elasticsearch
- netty-transport-classes-epoll & netty-transport-native-unix-common were coming from netty-transport-native-epoll

Following vulnerabilities were flagged by dependency checker:
<img width="1405" alt="Screenshot 2025-04-15 at 12 41 22" src="https://github.com/user-attachments/assets/de6165db-c80c-4e12-9223-04fc4b63b8b4" />

Also see build: https://build.hmcts.net/view/PRL/job/HMCTS_j_to_z_Nightly/job/prl-cos-api/job/master/928/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
