### PR TITLE
FPVTL-592

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/testingsupport/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/testingsupport/TestingSupportController.java
@@ -181,6 +181,25 @@ public class TestingSupportController {
         }
     }
 
+    @PostMapping(path = "/create-dummy-citizen-case-with-body")
+    @Operation(description = "Initiate the dummy citizen case creation for testing support using a given request body")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Dummy case created"),
+        @ApiResponse(responseCode = "401", description = "Provided Authorization token is missing or invalid"),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+    })
+    public CaseData createDummyCitizenCaseWithBody(
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
+        @RequestHeader(PrlAppsConstants.SERVICE_AUTHORIZATION_HEADER) String s2sToken,
+        @RequestBody String jsonBody
+    ) throws Exception {
+        if (authorisationService.isAuthorized(authorisation, s2sToken)) {
+            return testingSupportService.createDummyLiPC100CaseWithBody(authorisation, s2sToken, jsonBody);
+        } else {
+            throw (new RuntimeException(INVALID_CLIENT));
+        }
+    }
+
     @PostMapping(path = "/submitted-payment-confirmation", consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
     @Operation(description = "Confirm the payment for testing support")
     @ApiResponses(value = {

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
@@ -440,7 +440,8 @@ public class TestingSupportService {
         }
     }
 
-    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws RuntimeException, JsonProcessingException {
+    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws RuntimeException,
+        JsonProcessingException {
         if (isAuthorized(authorisation, s2sToken)) {
             CaseDetails dummyCaseDetails = objectMapper.readValue(
                 jsonBody,

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.prl.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -439,7 +440,7 @@ public class TestingSupportService {
         }
     }
 
-    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws Exception {
+    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws RuntimeException, JsonProcessingException {
         if (isAuthorized(authorisation, s2sToken)) {
             CaseDetails dummyCaseDetails = objectMapper.readValue(
                 jsonBody,

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
@@ -439,6 +439,24 @@ public class TestingSupportService {
         }
     }
 
+    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws Exception {
+        if (isAuthorized(authorisation, s2sToken)) {
+            CaseDetails dummyCaseDetails = objectMapper.readValue(
+                jsonBody,
+                CaseDetails.class
+            );
+            CaseDetails caseDetails = citizenCaseService.createCase(CaseUtils.getCaseData(
+                dummyCaseDetails,
+                objectMapper
+            ), authorisation);
+            CaseData createdCaseData = CaseUtils.getCaseData(caseDetails, objectMapper);
+            return createdCaseData.toBuilder().noOfDaysRemainingToSubmitCase(
+                CaseUtils.getRemainingDaysSubmitCase(createdCaseData)).build();
+        } else {
+            throw (new RuntimeException(INVALID_CLIENT));
+        }
+    }
+
     private boolean isAuthorized(String authorisation, String s2sToken) {
         return launchDarklyClient.isFeatureEnabled(TESTING_SUPPORT_LD_FLAG_ENABLED)
             && Boolean.TRUE.equals(authorisationService.authoriseUser(authorisation))

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/TestingSupportService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.prl.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -440,8 +439,7 @@ public class TestingSupportService {
         }
     }
 
-    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws RuntimeException,
-        JsonProcessingException {
+    public CaseData createDummyLiPC100CaseWithBody(String authorisation, String s2sToken, String jsonBody) throws Exception {
         if (isAuthorized(authorisation, s2sToken)) {
             CaseDetails dummyCaseDetails = objectMapper.readValue(
                 jsonBody,

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/testingsupport/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/testingsupport/TestingSupportControllerTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.prl.controllers.testingsupport.TestingSupportController;
 import uk.gov.hmcts.reform.prl.enums.State;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.services.AuthorisationService;
@@ -93,6 +92,14 @@ public class TestingSupportControllerTest {
     }
 
     @Test
+    public void testCreateDummyCitizenCaseWithBody() throws Exception {
+        String testBody = "test body";
+        when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        testingSupportController.createDummyCitizenCaseWithBody(authToken, s2sToken, testBody);
+        verify(testingSupportService, times(1)).createDummyLiPC100CaseWithBody(Mockito.anyString(), Mockito.anyString(), Mockito.matches(testBody));
+    }
+
+    @Test
     public void testFillRespondentTaskList() throws Exception {
         testingSupportController.fillRespondentTaskList(authToken, s2sToken, callbackRequest);
         verify(testingSupportService, times(1)).initiateRespondentResponseCreation(Mockito.anyString(), Mockito.any(
@@ -138,11 +145,21 @@ public class TestingSupportControllerTest {
     }
 
     @Test
-    public void testExeptionForCreateDummyCitizenCase() {
+    public void testExceptionForCreateDummyCitizenCase() {
         Mockito.when(authorisationService.isAuthorized(authToken, s2sToken)).thenReturn(false);
         assertExpectedException(() -> {
             testingSupportController.createDummyCitizenCase(authToken, s2sToken);
         }, RuntimeException.class, "Invalid Client");
+    }
+
+    @Test
+    public void testExceptionForCreateDummyCitizenCaseWithBody() {
+        Mockito.when(authorisationService.isAuthorized(authToken, s2sToken)).thenReturn(false);
+        assertExpectedException(() -> testingSupportController.createDummyCitizenCaseWithBody(
+            authToken,
+            s2sToken,
+            "test body"
+        ), RuntimeException.class, "Invalid Client");
     }
 
     @Test


### PR DESCRIPTION
### Change description ###

- Add testing support endpoint to create a dummy citizen case that uses a supplied request body to create the case, so that is can be used more flexibly when testing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
