### PR TITLE
FPVTL-605 Add extra logging to diagnose fm5 notification failures

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/services/Fm5ReminderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/Fm5ReminderService.java
@@ -91,10 +91,11 @@ public class Fm5ReminderService {
             //Iterate all cases to evaluate rules to trigger FM5 reminder
             Map<String, Fm5PendingParty> qualifiedCasesAndPartiesBeforeHearing =
                 getQualifiedCasesAndHearingsForNotifications(caseDetailsList, hearingAwayDays);
-
+            log.info("final list of cases to process for FM5 notifications: {}", qualifiedCasesAndPartiesBeforeHearing);
             //Send FM5 reminders to cases meeting all system rules, else update not needed
             qualifiedCasesAndPartiesBeforeHearing.forEach(
                 (key, fm5PendingParty) -> {
+                    log.info("Processing FM5 notification for case {}",key);
                     StartAllTabsUpdateDataContent startAllTabsUpdateDataContent;
                     Map<String, Object> caseDataUpdated = new HashMap<>();
                     if (Fm5PendingParty.NOTIFICATION_NOT_REQUIRED.equals(fm5PendingParty)) {


### PR DESCRIPTION
Investigation for https://tools.hmcts.net/jira/browse/FPVTL-605

Adding expanded logging due to cases being missed by FM5 notification task. 