### PR TITLE
Update TS-Support draft cases to be complete on creation

### DIFF
--- a/src/main/resources/C100_Dummy_Draft_CaseDetails_v3.json
+++ b/src/main/resources/C100_Dummy_Draft_CaseDetails_v3.json
@@ -852,7 +852,43 @@
           "cafcassOfficerPosition": null,
           "cafcassOfficerEmailAddress": null,
           "cafcassOfficerOtherPosition": null,
-          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born"
+          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born",
+          "whoDoesTheChildLiveWith": {
+            "value": {
+              "code": "7663081e-778d-4317-b278-7642b740d317",
+              "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+            },
+            "list_items": [
+              {
+                "code": "7663081e-778d-4317-b278-7642b740d317",
+                "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+              },
+              {
+                "code": "0016cff5-17f0-42af-bea4-0b04ca74c9ec",
+                "label": "Jeremy Anderson - Buckingham Palace, SW1A 1AA"
+              },
+              {
+                "code": "7e9028ba-534c-42bb-bb04-e67b6551b4bd",
+                "label": "Martina Graham - Victoria Coach Station Ltd, 164 Buckingham Palace Road, SW1W 9TP"
+              },
+              {
+                "code": "e406bcc3-3c91-45db-9dcc-3a5c14930851",
+                "label": "Mary Richards"
+              },
+              {
+                "code": "8d5140d5-18eb-4278-b41c-2a6fabdf4491",
+                "label": "Elise Lynn"
+              },
+              {
+                "code": "62614c4a-4faf-48c0-abfd-c579ef700fd4",
+                "label": "David Carman"
+              },
+              {
+                "code": "6bb5e9ac-df97-4593-8b22-3969dc0bb4e1",
+                "label": "Sam Nolan"
+              }
+            ]
+          }
         }
       },
       {
@@ -875,7 +911,43 @@
           "cafcassOfficerPosition": null,
           "cafcassOfficerEmailAddress": null,
           "cafcassOfficerOtherPosition": null,
-          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born"
+          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born",
+          "whoDoesTheChildLiveWith": {
+            "value": {
+              "code": "7663081e-778d-4317-b278-7642b740d317",
+              "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+            },
+            "list_items": [
+              {
+                "code": "7663081e-778d-4317-b278-7642b740d317",
+                "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+              },
+              {
+                "code": "0016cff5-17f0-42af-bea4-0b04ca74c9ec",
+                "label": "Jeremy Anderson - Buckingham Palace, SW1A 1AA"
+              },
+              {
+                "code": "7e9028ba-534c-42bb-bb04-e67b6551b4bd",
+                "label": "Martina Graham - Victoria Coach Station Ltd, 164 Buckingham Palace Road, SW1W 9TP"
+              },
+              {
+                "code": "e406bcc3-3c91-45db-9dcc-3a5c14930851",
+                "label": "Mary Richards"
+              },
+              {
+                "code": "8d5140d5-18eb-4278-b41c-2a6fabdf4491",
+                "label": "Elise Lynn"
+              },
+              {
+                "code": "62614c4a-4faf-48c0-abfd-c579ef700fd4",
+                "label": "David Carman"
+              },
+              {
+                "code": "6bb5e9ac-df97-4593-8b22-3969dc0bb4e1",
+                "label": "Sam Nolan"
+              }
+            ]
+          }
         }
       },
       {
@@ -898,7 +970,43 @@
           "cafcassOfficerPosition": null,
           "cafcassOfficerEmailAddress": null,
           "cafcassOfficerOtherPosition": null,
-          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born"
+          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born",
+          "whoDoesTheChildLiveWith": {
+            "value": {
+              "code": "7663081e-778d-4317-b278-7642b740d317",
+              "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+            },
+            "list_items": [
+              {
+                "code": "7663081e-778d-4317-b278-7642b740d317",
+                "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+              },
+              {
+                "code": "0016cff5-17f0-42af-bea4-0b04ca74c9ec",
+                "label": "Jeremy Anderson - Buckingham Palace, SW1A 1AA"
+              },
+              {
+                "code": "7e9028ba-534c-42bb-bb04-e67b6551b4bd",
+                "label": "Martina Graham - Victoria Coach Station Ltd, 164 Buckingham Palace Road, SW1W 9TP"
+              },
+              {
+                "code": "e406bcc3-3c91-45db-9dcc-3a5c14930851",
+                "label": "Mary Richards"
+              },
+              {
+                "code": "8d5140d5-18eb-4278-b41c-2a6fabdf4491",
+                "label": "Elise Lynn"
+              },
+              {
+                "code": "62614c4a-4faf-48c0-abfd-c579ef700fd4",
+                "label": "David Carman"
+              },
+              {
+                "code": "6bb5e9ac-df97-4593-8b22-3969dc0bb4e1",
+                "label": "Sam Nolan"
+              }
+            ]
+          }
         }
       },
       {
@@ -921,7 +1029,43 @@
           "cafcassOfficerPosition": null,
           "cafcassOfficerEmailAddress": null,
           "cafcassOfficerOtherPosition": null,
-          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born"
+          "parentalResponsibilityDetails": "Child's father and was married to the mother when child was born",
+          "whoDoesTheChildLiveWith": {
+            "value": {
+              "code": "7663081e-778d-4317-b278-7642b740d317",
+              "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+            },
+            "list_items": [
+              {
+                "code": "7663081e-778d-4317-b278-7642b740d317",
+                "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+              },
+              {
+                "code": "0016cff5-17f0-42af-bea4-0b04ca74c9ec",
+                "label": "Jeremy Anderson - Buckingham Palace, SW1A 1AA"
+              },
+              {
+                "code": "7e9028ba-534c-42bb-bb04-e67b6551b4bd",
+                "label": "Martina Graham - Victoria Coach Station Ltd, 164 Buckingham Palace Road, SW1W 9TP"
+              },
+              {
+                "code": "e406bcc3-3c91-45db-9dcc-3a5c14930851",
+                "label": "Mary Richards"
+              },
+              {
+                "code": "8d5140d5-18eb-4278-b41c-2a6fabdf4491",
+                "label": "Elise Lynn"
+              },
+              {
+                "code": "62614c4a-4faf-48c0-abfd-c579ef700fd4",
+                "label": "David Carman"
+              },
+              {
+                "code": "6bb5e9ac-df97-4593-8b22-3969dc0bb4e1",
+                "label": "Sam Nolan"
+              }
+            ]
+          }
         }
       },
       {
@@ -944,7 +1088,43 @@
           "cafcassOfficerPosition": null,
           "cafcassOfficerEmailAddress": null,
           "cafcassOfficerOtherPosition": null,
-          "parentalResponsibilityDetails": "To the third person"
+          "parentalResponsibilityDetails": "To the third person",
+          "whoDoesTheChildLiveWith": {
+            "value": {
+              "code": "7663081e-778d-4317-b278-7642b740d317",
+              "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+            },
+            "list_items": [
+              {
+                "code": "7663081e-778d-4317-b278-7642b740d317",
+                "label": "John Doe - Ministry Of Justice, Seventh Floor 102 Petty France, SW1H 9AJ"
+              },
+              {
+                "code": "0016cff5-17f0-42af-bea4-0b04ca74c9ec",
+                "label": "Jeremy Anderson - Buckingham Palace, SW1A 1AA"
+              },
+              {
+                "code": "7e9028ba-534c-42bb-bb04-e67b6551b4bd",
+                "label": "Martina Graham - Victoria Coach Station Ltd, 164 Buckingham Palace Road, SW1W 9TP"
+              },
+              {
+                "code": "e406bcc3-3c91-45db-9dcc-3a5c14930851",
+                "label": "Mary Richards"
+              },
+              {
+                "code": "8d5140d5-18eb-4278-b41c-2a6fabdf4491",
+                "label": "Elise Lynn"
+              },
+              {
+                "code": "62614c4a-4faf-48c0-abfd-c579ef700fd4",
+                "label": "David Carman"
+              },
+              {
+                "code": "6bb5e9ac-df97-4593-8b22-3969dc0bb4e1",
+                "label": "Sam Nolan"
+              }
+            ]
+          }
         }
       }
     ],

--- a/src/main/resources/FL401_Dummy_Draft_CaseDetails.json
+++ b/src/main/resources/FL401_Dummy_Draft_CaseDetails.json
@@ -916,7 +916,7 @@
       "partyId": "f2847b15-dbb8-4df0-868a-420d9de11d29",
       "dxNumber": null,
       "landline": null,
-      "lastName": "Smith",
+      "lastName": "Potato",
       "liveInRefuge": "No",
       "response": {
         "miam": {

--- a/src/main/resources/FL401_Dummy_Draft_CaseDetails.json
+++ b/src/main/resources/FL401_Dummy_Draft_CaseDetails.json
@@ -916,7 +916,7 @@
       "partyId": "f2847b15-dbb8-4df0-868a-420d9de11d29",
       "dxNumber": null,
       "landline": null,
-      "lastName": "Potato",
+      "lastName": "Smith",
       "liveInRefuge": "No",
       "response": {
         "miam": {

--- a/src/main/resources/FL401_Dummy_Draft_CaseDetails.json
+++ b/src/main/resources/FL401_Dummy_Draft_CaseDetails.json
@@ -917,6 +917,7 @@
       "dxNumber": null,
       "landline": null,
       "lastName": "Smith",
+      "liveInRefuge": "No",
       "response": {
         "miam": {
           "attendedMiam": null,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -425,8 +425,8 @@ test-url: ${TEST_URL:http://localhost:4044}
 
 core_case_data:
   api:
-    #url: ${CORE_CASE_DATA_API_URL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
-    url: ${CORE_CASE_DATA_API_URL:https://ccd-data-store-api-prl-ccd-definitions-pr-2755.preview.platform.hmcts.net/}
+    url: ${CORE_CASE_DATA_API_URL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
+    #url: ${CORE_CASE_DATA_API_URL:https://ccd-data-store-api-prl-ccd-definitions-pr-2682.preview.platform.hmcts.net/}
 
 
 auth:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -425,8 +425,8 @@ test-url: ${TEST_URL:http://localhost:4044}
 
 core_case_data:
   api:
-    url: ${CORE_CASE_DATA_API_URL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
-    #url: ${CORE_CASE_DATA_API_URL:https://ccd-data-store-api-prl-ccd-definitions-pr-2682.preview.platform.hmcts.net/}
+    #url: ${CORE_CASE_DATA_API_URL:http://ccd-data-store-api-aat.service.core-compute-aat.internal}
+    url: ${CORE_CASE_DATA_API_URL:https://ccd-data-store-api-prl-ccd-definitions-pr-2755.preview.platform.hmcts.net/}
 
 
 auth:


### PR DESCRIPTION
### Change description ###
Update TS-Support draft cases to be complete on creation, this covers: 
- updating FL401 to have refuge question set to "No" on creation
- updating C100 to have child details complete on creation


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
