### PR TITLE
FPVTL-762: Disable AUTO_CLOSE_JSON_CONTENT

### DIFF
--- a/src/contractTest/resources/application.yaml
+++ b/src/contractTest/resources/application.yaml
@@ -22,6 +22,9 @@ spring:
   main:
     allow-bean-definition-overriding: true
     allow-circular-references: true
+  jackson:
+    generator:
+      auto-close-json-content: false
 #  datasource:
 #    driver-class-name: org.postgresql.Driver
 #    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}${DB_OPTIONS:}

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -47,6 +47,9 @@ spring:
   main:
     allow-circular-references: true
     allow-bean-definition-overriding: true
+  jackson:
+    generator:
+      auto-close-json-content: false
   test:
     context:
       cache:

--- a/src/integrationTest/java/uk/gov/hmcts/reform/prl/ServiceContextConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/prl/ServiceContextConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.prl;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -99,6 +100,7 @@ public class ServiceContextConfiguration {
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        objectMapper.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
 
         return objectMapper;
     }

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -51,6 +51,9 @@ spring:
   main:
     allow-circular-references: true
     allow-bean-definition-overriding: true
+  jackson:
+    generator:
+      auto-close-json-content: false
 
 azure:
   application-insights:

--- a/src/main/java/uk/gov/hmcts/reform/prl/mapper/AppObjectMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/mapper/AppObjectMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.prl.mapper;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -20,6 +21,7 @@ public class AppObjectMapper {
         }
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         om.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+        om.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
         return om;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/prl/mapper/CcdObjectMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/mapper/CcdObjectMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.prl.mapper;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -20,6 +21,7 @@ public class CcdObjectMapper {
         }
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         om.enable(SerializationFeature.WRITE_ENUM_KEYS_USING_INDEX);
+        om.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
         return om;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/prl/utils/verifiers/JacksonConfigurationVerifier.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/utils/verifiers/JacksonConfigurationVerifier.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.prl.utils.verifiers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@SuppressWarnings("unused")
+public class JacksonConfigurationVerifier {
+
+    @Autowired
+    public JacksonConfigurationVerifier(ObjectMapper objectMapper) {
+        if (objectMapper.getFactory().isEnabled(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)) {
+            throw new IllegalStateException(
+                "Jackson ObjectMapper is configured with AUTO_CLOSE_JSON_CONTENT enabled. "
+                    + "This can cause issues with streaming JSON responses an must be disabled.");
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,6 +51,9 @@ spring:
   main:
     allow-circular-references: true
     allow-bean-definition-overriding: true
+  jackson:
+    generator:
+      auto-close-json-content: false
 
 azure:
   application-insights:

--- a/src/smokeTest/resources/application.yaml
+++ b/src/smokeTest/resources/application.yaml
@@ -51,6 +51,9 @@ spring:
   main:
     allow-circular-references: true
     allow-bean-definition-overriding: true
+  jackson:
+    generator:
+      auto-close-json-content: false
 
 azure:
   application-insights:

--- a/src/test/java/uk/gov/hmcts/reform/prl/utils/verifiers/JacksonConfigurationVerifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/utils/verifiers/JacksonConfigurationVerifierTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.prl.utils.verifiers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JacksonConfigurationVerifierTest {
+
+    @Test
+    void shouldThrowExceptionWhenObjectMapperIsConfiguredIncorrectly() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.getFactory().enable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+
+        assertThrows(IllegalStateException.class, () -> new JacksonConfigurationVerifier(objectMapper),
+            "Jackson ObjectMapper is configured with AUTO_CLOSE_JSON_CONTENT enabled. "
+                + "This can cause issues with streaming JSON responses and must be disabled.");
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenObjectMapperIsConfiguredCorrectly() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.getFactory().disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+
+        assertDoesNotThrow(() -> new JacksonConfigurationVerifier(objectMapper));
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPVTL-762](https://tools.hmcts.net/jira/browse/FPVTL-762)


### Change description ###
 - Disables AUTO_CLOSE_JSON_CONTENT on both object mappers
 - Add validator to confirm it's disabled on startup on primary object mapper


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
