### PR TITLE
FPVTL-1045: Add null checking for failed bundles on Cafcass API

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CaseDataService.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CANCELLED;
 
 @Slf4j
@@ -319,11 +320,14 @@ public class CaseDataService {
             && null != caseData.getBundleInformation().getCaseBundles()
             && CollectionUtils.isNotEmpty(caseData.getBundleInformation().getCaseBundles())) {
             caseData.getBundleInformation().getCaseBundles().parallelStream().forEach(bundle -> {
-                uk.gov.hmcts.reform.prl.models.documents.Document document = uk.gov.hmcts.reform.prl.models.documents.Document.builder()
-                    .documentFileName(bundle.getValue().getStitchedDocument().documentFilename)
-                    .documentUrl(bundle.getValue().getStitchedDocument().getDocumentUrl())
-                    .build();
-                addInOtherDocuments("courtBundle", document, otherDocsList);
+                if (isNotEmpty(bundle.getValue().getStitchedDocument())) {
+                    uk.gov.hmcts.reform.prl.models.documents.Document document =
+                        uk.gov.hmcts.reform.prl.models.documents.Document.builder()
+                            .documentFileName(bundle.getValue().getStitchedDocument().getDocumentFilename())
+                            .documentUrl(bundle.getValue().getStitchedDocument().getDocumentUrl())
+                            .build();
+                    addInOtherDocuments("courtBundle", document, otherDocsList);
+                }
             });
         }
     }

--- a/src/test/resources/response/CafcassResponseNullBundles.json
+++ b/src/test/resources/response/CafcassResponseNullBundles.json
@@ -1,0 +1,258 @@
+{
+  "total": 1,
+  "cases": [
+    {
+      "id": 1673950629515891,
+      "jurisdiction": "PRIVATELAW",
+      "state": "DECISION_OUTCOME",
+      "caseTypeOfApplication": "C100",
+      "case_type_id": "PRLAPPS",
+      "created_date": [
+        2023,
+        1,
+        17,
+        10,
+        17,
+        9,
+        531000000
+      ],
+      "last_modified": [
+        2023,
+        1,
+        24,
+        16,
+        52,
+        6,
+        18000000
+      ],
+      "case_data": {
+        "dateSubmitted": "2023-01-17",
+        "caseTypeOfApplication": "C100",
+        "draftConsentOrderFile": {
+          "document_filename": "dummy.pdf",
+          "document_id": "f2c3d308-5ba3-4a35-bbc0-98d800cf8ba6"
+        },
+        "childrenKnownToLocalAuthority": "yes",
+        "finalDocument": {
+          "document_filename": "C100FinalDocument.pdf",
+          "document_id": "f90975ac-a72b-4f44-9336-a3d41c756825"
+        },
+        "ordersApplyingFor": [
+          "childArrangementsOrder",
+          "prohibitedStepsOrder",
+          "specificIssueOrder"
+        ],
+        "children": [
+          {
+            "id": "1e67141d-e255-43ec-81ff-89b868b23be3",
+            "value": {
+              "firstName": "Test Firstnamee",
+              "lastName": "Test Lastnam",
+              "dateOfBirth": "2005-11-11",
+              "gender": "male",
+              "orderAppliedFor": [
+                "childArrangementsOrder"
+              ],
+              "applicantsRelationshipToChild": "stepFather",
+              "respondentsRelationshipToChild": "mother",
+              "childLiveWith": [
+                "applicant"
+              ],
+              "parentalResponsibilityDetails": "Text area field Test",
+              "whoDoesTheChildLiveWith": {
+                "partyId": "46cc0086-405a-423c-81d9-1a835ee82246",
+                "partyFullName": "David Carman",
+                "partyType": "applicant"
+              }
+            }
+          },
+          {
+            "id": "23f8d903-e423-4bb7-84e4-0d5d455e4408",
+            "value": {
+              "firstName": "Test Firstname2",
+              "lastName": "Test Lastname2",
+              "dateOfBirth": "2005-11-22",
+              "gender": "female",
+              "orderAppliedFor": [
+                "childArrangementsOrder"
+              ],
+              "applicantsRelationshipToChild": "stepFather",
+              "respondentsRelationshipToChild": "mother",
+              "childLiveWith": [
+                "applicant"
+              ],
+              "parentalResponsibilityDetails": "Text area field Test",
+              "whoDoesTheChildLiveWith": {
+                "partyId": "46cc0086-405a-423c-81d9-1a835ee82246",
+                "partyFullName": "David Carman",
+                "partyType": "applicant"
+              }
+            }
+          }
+        ],
+        "miamCertificationDocumentUpload1": {
+          "document_filename": "dummy.pdf",
+          "document_id": "1b5e9369-48f9-4801-bed2-8a7457a6ed83"
+        },
+        "miamExemptionsTable": {
+          "reasonsForMiamExemption": "Domestic violence, Child Protection Concern, Urgency, Previous MIAM attendance or previous MIAM exemption, Other",
+          "domesticViolenceEvidence": "Evidence which demonstrates that a prospective party has been, or is at risk of being, the victim of domestic violence by another prospective party in the form of abuse which relates to financial matters.\nA letter from the Secretary of State for the Home Department confirming that a prospective party has been granted leave to remain in the United Kingdom under paragraph 289B of the Rules made by the Home Secretary under section 3(2) of the Immigration Act 1971, which can be found at https://www. gov.uk/guidance/immigration-rules/immigration-rules-index;\nA letter from a public authority confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party (or a copy of that assessment);\nA letter or report from an organisation providing domestic violence support services in the United Kingdom confirming- \r\n(i) that a person with whom a prospective party is or was in a family relationship was refused admission to a refuge; \r\n(ii) the date on which they were refused admission to the refuge; and \r\n(iii)they sought admission to the refuge because of allegations of domestic violence by the prospective party referred to in paragraph (i);\nA letter which- \r\n(i) is from an organisation providing domestic violence support services, or a registered charity, which letter confirms that it- \r\n(a) is situated in England and Wales, \r\n(b) has been operating for an uninterrupted period of six months or more; and \r\n(c) provided a prospective party with support in relation to that person’s needs as a victim, or a person at risk, of domestic violence; and \r\n(ii) contains- \r\n(a) a statement to the effect that, in the reasonable professional judgment of the author of the letter, the prospective party is, or is at risk of being, a victim of domestic violence; \r\n(b) a description of the specific matters relied upon to support that judgment; \r\n(c) a description of the support provided to the prospective party; and \r\n(d) a statement of the reasons why the prospective party needed that support;\nA letter from an officer employed by a local authority or housing association (or their equivalent in Scotland or Northern Ireland) for the purpose of supporting tenants containing- \r\n(i)  a statement to the effect that, in their reasonable professional judgment, a person with whom a prospective party is or has been in a family relationship is, or is at risk of being, a victim of domestic violence by that prospective party; (ii)  a description of the specific matters relied upon to support that judgment; and (iii) a description of the support they provided to the victim of domestic violence or the person at risk of domestic violence by that prospective party;\nA letter from an independent sexual violence advisor confirming that they are providing support to a prospective party relating to sexual violence by another prospective party;\nA letter from an independent domestic violence advisor confirming that they are providing support to a prospective party;\nA letter from any person who is a member of a multi-agency risk assessment conference (or other suitable local safeguarding forum) confirming that a prospective party, or a person with whom that prospective party is in a family relationship, is or has been at risk of harm from domestic violence by another prospective party;\nA letter or report from- \r\n(i) the appropriate health professional who made the referral described below; \r\n(ii) an appropriate health professional who has access to the medical records of the prospective party referred to below; or \r\n(iii) the person to whom the referral described below was made; \r\nconfirming that there was a referral by an appropriate health professional of a prospective party to a person who provides specialist support or assistance for victims of, or those at risk of, domestic violence;\nA letter or report from an appropriate health professional confirming that- \r\n(i)  that professional,or another appropriate health professional, has examined a prospective party in person; and (ii)  in the reasonable professional judgment of the author or the examining appropriate health professional, that prospective party has, or has had, injuries or a condition consistent with being a victim of domestic violence;\nAn expert report produced as evidence in proceedings in the United Kingdom for the benefit of a court or tribunal confirming that a person with whom a prospective party is or was in a family relationship, was assessed as being, or at risk of being, a victim of domestic violence by that prospective party;\nA copy of a finding of fact, made in proceedings in the United Kingdom, that there has been domestic violence by a prospective party;\nAn undertaking given in England and Wales under section 46 or 63E of the Family Law Act 1996 (or given in Scotland or Northern Ireland in place of a protective injunction) by a prospective party, provided that a cross- undertaking relating to domestic violence was not given by another prospective party;\nA relevant protective injunction;\nA domestic violence protection notice issued under section 24 of the Crime and Security Act 2010 against a prospective party;\nA court order binding a prospective party over in connection with a domestic violence offence;\nEvidence of a relevant conviction for a domestic violence offence;\nEvidence of relevant criminal proceedings for a domestic violence offence which have not concluded;\nEvidence of a relevant police caution for a domestic violence offence;\nEvidence that a prospective party has been arrested for a relevant domestic violence offence;",
+          "urgencyEvidence": "There  is a significant risk that in the period necessary to schedule and attend a MIAM, proceedings relating to the dispute will be brought in another state in which a valid claim to jurisdiction may exist, such that a court in that other State would be seized of the dispute before a court in England and Wales.\nAny delay caused by MIAM would cause irretrievable problems in dealing with the dispute (including the irretrievable loss of significant evidence)\nAny delay caused by MIAM would cause unreasonable hardship to the prospective applicant\nAny delay caused by MIAM would cause significant risk of a miscarriage of justice\nThere is risk to the life, liberty or physical safety of the prospective applicant or his or her family or his or her home; or",
+          "childProtectionEvidence": "The subject of enquiries by a local authority under section 47 of the Children Act 1989 Act\nThe subject of a child protection plan put in place by a local authority",
+          "previousAttendenceEvidence": "In the 4 months prior to making the application, the person filed a relevant family application confirming that a MIAM exemption applied and that application related to the same or substantially the same dispute",
+          "otherGroundsEvidence": "(i) the prospective applicant is or all of the prospective respondents are subject to a disability or other inability that would prevent attendance at a MIAM unless appropriate facilities can be offered by an authorised mediator; (ii) the prospective applicant has contacted as many authorised family mediators as have an office within fifteen miles of his or her home (or three of them if there are three or more), and all have stated that they are unable to provide such facilities; and (iii)the names, postal addresses and telephone numbers or e-mail addresses for such authorised family mediators, and the dates of contact, can be provided to the court if requested."
+        },
+        "applicants": [
+          {
+            "id": "c9c53318-a61a-456a-a39f-27f4487b207e",
+            "value": {
+              "firstName": "Applicant Firstname",
+              "lastName": "Applicant Lastname",
+              "dateOfBirth": "1990-10-10",
+              "gender": "male",
+              "placeOfBirth": "London",
+              "isAddressConfidential": "Yes",
+              "isAtAddressLessThan5Years": "Yes",
+              "addressLivedLessThan5YearsDetails": "Same address for last 5 years",
+              "canYouProvideEmailAddress": "Yes",
+              "isEmailAddressConfidential": "Yes",
+              "isPhoneNumberConfidential": "Yes",
+              "solicitorOrg": {
+                "OrganisationID": "EJK3DHI",
+                "OrganisationName": "pppptest1"
+              },
+              "solicitorAddress": {
+                "AddressLine1": "Physio In The City",
+                "AddressLine2": "1 Kingdom Street",
+                "PostCode": "W2 6BD"
+              },
+              "representativeFirstName": "Ted",
+              "representativeLastName": "Robinson",
+              "solicitorEmail": "test@example.com",
+              "phoneNumber": "44646456456",
+              "email": "applicant@gmail.com",
+              "address": {
+                "AddressLine1": "1 Selsdon Road",
+                "PostTown": "London",
+                "Country": "United Kingdom",
+                "PostCode": "E13 9BY"
+              }
+            }
+          }
+        ],
+        "respondents": [
+          {
+            "id": "30293a08-1ade-4474-9fa7-2c3ebd847f19",
+            "value": {
+              "firstName": "Respondent Firstname",
+              "lastName": "Respondent Lastname",
+              "dateOfBirth": "1995-11-10",
+              "gender": "male",
+              "placeOfBirth": "Birmingham",
+              "addressLivedLessThan5YearsDetails": "Text area",
+              "canYouProvideEmailAddress": "Yes",
+              "isDateOfBirthKnown": "Yes",
+              "isCurrentAddressKnown": "Yes",
+              "canYouProvidePhoneNumber": "Yes",
+              "isPlaceOfBirthKnown": "Yes",
+              "solicitorOrg": {
+                "OrganisationID": "EJK3DHI",
+                "OrganisationName": "pppptest1"
+              },
+              "solicitorAddress": {
+                "AddressLine1": "Physio In The City",
+                "AddressLine2": "1 Kingdom Street",
+                "PostCode": "W2 6BD"
+              },
+              "representativeFirstName": "Ted",
+              "representativeLastName": "Robinson",
+              "isAtAddressLessThan5YearsWithDontKnow": "yes",
+              "doTheyHaveLegalRepresentation": "yes",
+              "solicitorEmail": "test@example.com",
+              "phoneNumber": "0712234667",
+              "email": "respondent@email.com",
+              "address": {
+                "AddressLine1": "1 Selsdon Road",
+                "PostTown": "London",
+                "Country": "United Kingdom",
+                "PostCode": "E13 9BY"
+              }
+            }
+          }
+        ],
+        "applicantSolicitorEmailAddress": "testways2payuser4@mailnesia.com",
+        "solicitorName": "firstName lastName",
+        "courtEpimsId": "12",
+        "courtName": "East London Family Court",
+        "ordersNonMolestationDocument": {
+          "document_filename": "dummy.pdf",
+          "document_id": "344eff7c-e13d-41c9-b596-90042d84df57"
+        },
+        "hearingData": {
+          "caseRef": "1673970714366224",
+          "caseHearings": [
+            {
+              "hearingID": 2000004659,
+              "hearingType": "ABA5-FFH",
+              "hmcStatus": "LISTED",
+              "hearingDaySchedule": [
+                {
+                  "hearingVenueName": "ROYAL COURTS OF JUSTICE - QUEENS BUILDING (AND WEST GREEN BUILDING)",
+                  "hearingStartDateTime": [
+                    2023,
+                    5,
+                    9,
+                    9,
+                    0
+                  ],
+                  "hearingEndDateTime": [
+                    2023,
+                    5,
+                    9,
+                    9,
+                    45
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "submitAndPayDownloadApplicationLink": {
+          "document_filename": "Draft_C100_application.pdf",
+          "document_id": "3750c631-214a-4882-8f60-8cf8086d6bc5"
+        },
+        "c8Document": {
+          "document_filename": "C8Document.pdf",
+          "document_id": "306dfbb6-b607-4d7f-8112-01b653450ede"
+        },
+        "c1ADocument": {
+          "document_filename": "C1A_Document.pdf",
+          "document_id": "f8da06eb-7725-429a-9015-126d89630ce2"
+        },
+        "caseManagementLocation": {
+          "regionId": "1",
+          "baseLocationId": "12",
+          "regionName": "London",
+          "baseLocationName": "Southampton"
+        },
+        "bundleInformation": {
+          "caseBundles": [
+            {
+              "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              "value": {
+                "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "title": "PRL Bundle",
+                "description": null,
+                "stitchStatus": "FAILED",
+                "stitchedDocument": null,
+                "eligibleForCloning": "no",
+                "stitchingFailureMessage": "Unknown file type: multipart/form-data",
+                "historicalStitchedDocument": null
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-1045


### Change description ###
 - Add null checking so we don't try and send empty documents on "failed" bundles.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
