### PR TITLE
FPVTL-1072 Write acro data in CSV with feature toggle for confidential data.

### DIFF
--- a/src/contractTest/resources/application.yaml
+++ b/src/contractTest/resources/application.yaml
@@ -629,5 +629,3 @@ acro:
   source-directory: /tmp/acro/source
   zip-password: ${ACRO_ZIP_PASSWORD:test1234}
   search-case-type-id: PRLAPPS
-  source-directory: /tmp/acro/source
-  output-directory: /tmp/acro/export

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -664,5 +664,3 @@ acro:
   source-directory: /tmp/acro/source
   zip-password: ${ACRO_ZIP_PASSWORD:test1234}
   search-case-type-id: PRLAPPS
-  source-directory: /tmp/acro/source
-  output-directory: /tmp/acro/export

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -802,5 +802,3 @@ acro:
   output-directory: /tmp/acro/export
   zip-password: ${ACRO_ZIP_PASSWORD:test1234}
   search-case-type-id: PRLAPPS
-  source-directory: /tmp/acro/source
-  output-directory: /tmp/acro/export

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -811,5 +811,3 @@ acro:
   source-directory: /tmp/acro/source
   zip-password: ${ACRO_ZIP_PASSWORD:test1234}
   search-case-type-id: PRLAPPS
-  source-directory: /tmp/acro/source
-  output-directory: /tmp/acro/export

--- a/src/smokeTest/resources/application.yaml
+++ b/src/smokeTest/resources/application.yaml
@@ -664,5 +664,3 @@ acro:
   source-directory: /tmp/acro/source
   zip-password: ${ACRO_ZIP_PASSWORD:test1234}
   search-case-type-id: PRLAPPS
-  source-directory: /tmp/acro/source
-  output-directory: /tmp/acro/export


### PR DESCRIPTION
# CsvWriter and Tests

This PR introduces the CsvWriter service and comprehensive unit tests for generating ACRO-compliant CSV manifests from finalised FL404a orders in CCD.

### JIRA link  ###
[Toggle for the confidential details appearing in the CSV file
](https://tools.hmcts.net/jira/browse/FPVTL-1072)

## Functionality
### CSV Generation:


- Produces a CSV file with one row per finalised FL404a order, matching the ACRO template structure and field order.
Excludes draft orders; only finalised orders are exported.
### Field Mapping & Formatting:


- Maps CCD case data to the correct CSV columns, including applicant/respondent details, addresses, postcodes, and dates (formatted as DD/MM/YYYY).
- Ensures all required fields are present and correctly ordered.
Confidentiality Toggle:


### confidentialAllowed flag:
- If true, all details are included.
- If false, confidential fields (applicant/respondent phone, email, address, postcode) are blanked in the output.
Confidentiality columns (e.g., “Is Confidential”) are populated with “Yes” or “No” based on Manage Cases flags.
## Error Handling:


- Skips records with missing/invalid required fields, logs the reason (e.g., “Missing postcode”), and continues processing valid cases.
## Tests
- Validate header creation and correct field mapping.
- Assert row data matches expected values and confidentiality logic.
- Confirm draft orders are excluded.
- Check that confidential fields are blanked when confidentialAllowed is false.
- Ensure graceful handling of nulls and incomplete data.
##  Meets Acceptance Criteria:
- Generates CSV for finalised FL404a orders only.
- Maps and formats fields per ACRO template.
- Excludes drafts.
- Includes confidentiality columns and toggles confidential data.
- Skips and logs invalid records.
- Blanks confidential fields when required.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
