### PR TITLE
FPVTL-2674: Ensure newly added info in response pulls through to the …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/services/c100respondentsolicitor/C100RespondentSolicitorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/c100respondentsolicitor/C100RespondentSolicitorService.java
@@ -1025,6 +1025,7 @@ public class C100RespondentSolicitorService {
             caseData = updateRefugeDocumentList(caseData, amended);
 
             String party = representedRespondent.getValue().getLabelForDynamicList();
+
             caseData.getRespondents().set(
                 caseData.getRespondents().indexOf(representedRespondent),
                 element(representedRespondent.getId(), amended)
@@ -1040,6 +1041,9 @@ public class C100RespondentSolicitorService {
             String createdBy = StringUtils.isEmpty(representedRespondent.getValue().getRepresentativeFullNameForCaseFlags())
                     ? party : representedRespondent.getValue().getRepresentativeFullNameForCaseFlags() + SOLICITOR;
             updatedCaseData.put(RESPONDENTS, caseData.getRespondents());
+
+            // representedRespondent uses amended details, so the correct details are pulled onto the C8
+            representedRespondent = element(representedRespondent.getId(), amended);
 
             Map<String, Object> dataMap = generateRespondentDocsAndUpdateCaseData(
                 authorisation,
@@ -1125,6 +1129,7 @@ public class C100RespondentSolicitorService {
                 .placeOfBirth(respondent.getResponse().getCitizenDetails().getPlaceOfBirth())
                 .liveInRefuge(respondent.getResponse().getCitizenDetails().getLiveInRefuge())
                 .address(respondent.getResponse().getCitizenDetails().getAddress())
+                .isCurrentAddressKnown(respondent.getResponse().getCitizenDetails().getAddress() != null ? YesOrNo.Yes : YesOrNo.No)
                 .email(respondent.getResponse().getCitizenDetails().getContact() != null
                         ? respondent.getResponse().getCitizenDetails().getContact().getEmail() : null)
                 .phoneNumber(respondent.getResponse().getCitizenDetails().getContact() != null


### PR DESCRIPTION
…C8 doc

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-2674


### Change description ###
 - Ensure the correct newly entered respondent info is pulled onto the generated doc


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
