### PR TITLE
FPVTL-2666: Add missing court type enum value

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/enums/citizen/CourtOrderTypeEnum.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/enums/citizen/CourtOrderTypeEnum.java
@@ -23,7 +23,7 @@ public enum CourtOrderTypeEnum {
     medicalTreatment("Medical treatment"),
     relocateChildrenDifferentUkAreaA("Relocating the children to a different area in England and Wales"),
     relocateChildrenOutsideUkA("Relocating the children outside of England and Wales (including Scotland and Northern Ireland)"),
-    returningChildrenToYourCare("Returning the children to your care");
+    returningChildrenToYourCare("Returning the children to your care"),
     specificIssueOrder("Specific Issue Order");
 
     private final String displayedValue;

--- a/src/main/java/uk/gov/hmcts/reform/prl/enums/citizen/CourtOrderTypeEnum.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/enums/citizen/CourtOrderTypeEnum.java
@@ -24,6 +24,7 @@ public enum CourtOrderTypeEnum {
     relocateChildrenDifferentUkAreaA("Relocating the children to a different area in England and Wales"),
     relocateChildrenOutsideUkA("Relocating the children outside of England and Wales (including Scotland and Northern Ireland)"),
     returningChildrenToYourCare("Returning the children to your care");
+    specificIssueOrder("Specific Issue Order");
 
     private final String displayedValue;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-2666

### Change description ###

There is a reoccurring exception when the citizen tries to submit a C100 application with an "specificIssueOrder" because that court order type is missing from the relevant enum class.
This change is adding the missing enum to avoid the exception and allow the C100 application to be able to land on Manage Case correctly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
