### PR TITLE
fpvtl-2707: Delink document to case when a document is removed

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -95,6 +96,9 @@ public class CaseDocumentControllerIntegrationTest {
 
     @MockitoBean
     private UserInfo userInfo;
+
+    @MockBean
+    AuthTokenGenerator authTokenGenerator;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -295,6 +299,7 @@ public class CaseDocumentControllerIntegrationTest {
         when(authorisationService.isAuthorized(anyString(), anyString())).thenReturn(true);
         when(authorisationService.authoriseUser(anyString())).thenReturn(Optional.of(userInfo));
         when(authorisationService.authoriseService(anyString())).thenReturn(true);
+        when(authTokenGenerator.generate()).thenReturn("testAuthToken");
 
         when(documentGenService.deleteDocument(anyString(), anyString())).thenReturn(DocumentResponse.builder()
                                                                                          .status("Success")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentControllerIntegrationTest.java
@@ -97,7 +97,7 @@ public class CaseDocumentControllerIntegrationTest {
     @MockitoBean
     private UserInfo userInfo;
 
-    @MockBean
+    @MockitoBean
     AuthTokenGenerator authTokenGenerator;
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -59,6 +60,7 @@ import uk.gov.hmcts.reform.prl.services.citizen.CaseService;
 import uk.gov.hmcts.reform.prl.services.citizen.CitizenDocumentService;
 import uk.gov.hmcts.reform.prl.services.document.DocumentGenService;
 import uk.gov.hmcts.reform.prl.utils.CaseUtils;
+import uk.gov.hmcts.reform.prl.utils.DocumentUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -92,6 +94,7 @@ public class CaseDocumentController {
     private final CaseService caseService;
     private final EmailService emailService;
     private final CitizenDocumentService citizenDocumentService;
+    private final AuthTokenGenerator authTokenGenerator;
 
     @Value("${citizen.url}")
     private String dashboardUrl;
@@ -372,7 +375,29 @@ public class CaseDocumentController {
         if (!isAuthorized(authorisation, serviceAuthorization)) {
             throw (new RuntimeException(INVALID_CLIENT));
         }
+        delinkCitizenUploadedDocument(authorisation, authTokenGenerator.generate(), documentId);
         return ResponseEntity.ok(documentGenService.deleteDocument(authorisation, documentId));
+    }
+
+    private void delinkCitizenUploadedDocument(String authorisation, String serviceAuthorization, String documentId) {
+        Optional<CaseData> matchedCaseData = Optional.ofNullable(caseService.retrieveCases(authorisation, serviceAuthorization))
+            .orElse(List.of())
+            .stream()
+            .filter(caseData -> isNotEmpty(caseData.getDocumentManagementDetails()))
+            .filter(caseData -> isNotEmpty(caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList()))
+            .filter(caseData -> caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList()
+                .stream()
+                .anyMatch(element -> isNotEmpty(element.getValue().getCitizenQuarantineDocument())
+                    && documentId.equalsIgnoreCase(DocumentUtils.getDocumentId(element.getValue().getCitizenQuarantineDocument().getDocumentUrl()))))
+            .findFirst();
+
+        if (matchedCaseData.isEmpty()) {
+            return;
+        }
+
+        CaseData caseDataToUpdate = matchedCaseData.get();
+        String caseId = String.valueOf(caseDataToUpdate.getId());
+        caseService.delinkCitizenUploadedDocumentFromCase(authorisation, caseId, documentId);
     }
 
     private boolean isAuthorized(String authorisation, String serviceAuthorization) {

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/citizen/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/citizen/CaseService.java
@@ -111,6 +111,7 @@ import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.AWAITING_HEARIN
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C100_CASE_TYPE;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CITIZEN;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CITIZEN_UPLOADED_DOCUMENT;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.COMMA;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.COMPLETED;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DD_MMM_YYYY_HH_MM_SS;
@@ -496,6 +497,52 @@ public class CaseService {
         }
 
         return citizenDocumentsManagement;
+    }
+
+    public void delinkCitizenUploadedDocumentFromCase(String authToken, String caseId, String documentId) {
+        UserInfo userInfo = idamClient.getUserInfo(authToken);
+        CaseEvent caseEvent = CaseEvent.fromValue(CITIZEN_UPLOADED_DOCUMENT);
+        EventRequestData eventRequestData = ccdCoreCaseDataService.eventRequest(
+            caseEvent,
+            userInfo.getUid()
+        );
+
+        StartEventResponse startEventResponse =
+            ccdCoreCaseDataService.startUpdate(
+                authToken,
+                eventRequestData,
+                caseId,
+                false
+            );
+
+        CaseData caseData = CaseUtils.getCaseData(startEventResponse.getCaseDetails(), objectMapper);
+
+        List<Element<QuarantineLegalDoc>> quarantineLegalDocList = Optional.ofNullable(
+                caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList()
+            )
+            .orElse(List.of())
+            .stream()
+            .filter(element -> !documentId.equalsIgnoreCase(
+                DocumentUtils.getDocumentId(element.getValue().getCitizenQuarantineDocument().getDocumentUrl())
+            ))
+            .toList();
+
+        Map<String, Object> quarantineLegalDocListMap = new HashMap<>();
+        quarantineLegalDocListMap.put("citizenQuarantineDocsList", quarantineLegalDocList);
+
+        CaseDataContent caseDataContent = ccdCoreCaseDataService.createCaseDataContent(
+            startEventResponse,
+            quarantineLegalDocListMap
+        );
+
+        ccdCoreCaseDataService.submitUpdate(
+            authToken,
+            eventRequestData,
+            caseDataContent,
+            caseId,
+            false
+        );
+
     }
 
     private List<CitizenDocuments> getCitizenApplicationPacks(CaseData caseData,

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/citizen/CaseDocumentControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
@@ -24,11 +25,13 @@ import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.framework.exceptions.DocumentGenerationException;
 import uk.gov.hmcts.reform.prl.models.Element;
 import uk.gov.hmcts.reform.prl.models.complextypes.PartyDetails;
+import uk.gov.hmcts.reform.prl.models.complextypes.QuarantineLegalDoc;
 import uk.gov.hmcts.reform.prl.models.complextypes.citizen.User;
 import uk.gov.hmcts.reform.prl.models.complextypes.citizen.documents.UploadedDocuments;
 import uk.gov.hmcts.reform.prl.models.documents.Document;
 import uk.gov.hmcts.reform.prl.models.documents.DocumentResponse;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.DocumentManagementDetails;
 import uk.gov.hmcts.reform.prl.models.dto.citizen.DeleteDocumentRequest;
 import uk.gov.hmcts.reform.prl.models.dto.citizen.DocumentRequest;
 import uk.gov.hmcts.reform.prl.models.dto.citizen.GenerateAndUploadDocumentRequest;
@@ -55,6 +58,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,6 +96,8 @@ class CaseDocumentControllerTest {
     private CitizenDocumentService citizenDocumentService;
     @Mock
     private UserInfo userInfo;
+    @Mock
+    private AuthTokenGenerator authTokenGenerator;
 
     @Test
     void testNotifyOtherPartiesRespondentCA() throws Exception {
@@ -459,11 +466,102 @@ class CaseDocumentControllerTest {
         when(authorisationService.authoriseUser(AUTH_TOKEN)).thenReturn(Optional.of(userInfo));
         when(authorisationService.authoriseService(S2S_TOKEN)).thenReturn(Boolean.TRUE);
         when(documentGenService.deleteDocument(AUTH_TOKEN, "TEST_DOCUMENT_ID")).thenReturn(documentResponse);
+        when(authTokenGenerator.generate()).thenReturn(S2S_TOKEN);
 
         //When
         ResponseEntity<?> response = caseDocumentController.deleteDocument(AUTH_TOKEN, S2S_TOKEN, "TEST_DOCUMENT_ID");
         //Then
         assertEquals(documentResponse, response.getBody());
+    }
+
+    @Test
+    void testDeleteDocumentDelinksCitizenUploadedDocumentFromCase() throws Exception {
+        DocumentResponse documentResponse = DocumentResponse.builder()
+            .status("SUCCESS")
+            .build();
+
+        Element<QuarantineLegalDoc> quarantineLegalDocElement = Element.<QuarantineLegalDoc>builder()
+            .id(UUID.fromString("00000000-0000-0000-0000-000000000123"))
+            .value(QuarantineLegalDoc.builder()
+                       .citizenQuarantineDocument(Document.builder()
+                                                        .documentUrl(
+                                                            "http://dm-store:8080/documents/00000000-0000-0000-0000-000000000123")
+                                                        .build())
+                       .build())
+            .build();
+
+        CaseData caseData = CaseData.builder()
+            .id(12345L)
+            .documentManagementDetails(
+                DocumentManagementDetails.builder()
+                    .citizenQuarantineDocsList(List.of(quarantineLegalDocElement))
+                    .build()
+            )
+            .build();
+
+        when(authorisationService.authoriseUser(AUTH_TOKEN)).thenReturn(Optional.of(userInfo));
+        when(authorisationService.authoriseService(S2S_TOKEN)).thenReturn(Boolean.TRUE);
+        when(caseService.retrieveCases(AUTH_TOKEN, S2S_TOKEN)).thenReturn(List.of(caseData));
+        when(documentGenService.deleteDocument(AUTH_TOKEN, "00000000-0000-0000-0000-000000000123")).thenReturn(documentResponse);
+        when(authTokenGenerator.generate()).thenReturn(S2S_TOKEN);
+
+        ResponseEntity<?> response = caseDocumentController.deleteDocument(
+            AUTH_TOKEN,
+            S2S_TOKEN,
+            "00000000-0000-0000-0000-000000000123"
+        );
+
+        verify(caseService).retrieveCases(AUTH_TOKEN, S2S_TOKEN);
+        verify(caseService).delinkCitizenUploadedDocumentFromCase(
+            AUTH_TOKEN,
+            "12345",
+            "00000000-0000-0000-0000-000000000123"
+        );
+        assertEquals(documentResponse, response.getBody());
+    }
+
+    @Test
+    void testDeleteDocumentThrowsCaseIdWhenDelinkCitizenUploadedDocumentFails() throws Exception {
+        Element<QuarantineLegalDoc> quarantineLegalDocElement = Element.<QuarantineLegalDoc>builder()
+            .id(UUID.randomUUID())
+            .value(QuarantineLegalDoc.builder()
+                       .citizenQuarantineDocument(Document.builder()
+                                                        .documentUrl(
+                                                            "http://dm-store:8080/documents/00000000-0000-0000-0000-000000000123")
+                                                        .build())
+                       .build())
+            .build();
+
+        CaseData caseData = CaseData.builder()
+            .id(12345L)
+            .documentManagementDetails(
+                DocumentManagementDetails.builder()
+                    .citizenQuarantineDocsList(List.of(quarantineLegalDocElement))
+                    .build()
+            )
+            .build();
+
+        when(authorisationService.authoriseUser(AUTH_TOKEN)).thenReturn(Optional.of(userInfo));
+        when(authorisationService.authoriseService(S2S_TOKEN)).thenReturn(Boolean.TRUE);
+        when(caseService.retrieveCases(AUTH_TOKEN, S2S_TOKEN)).thenReturn(List.of(caseData));
+        when(authTokenGenerator.generate()).thenReturn(S2S_TOKEN);
+        doThrow(new RuntimeException("test failure"))
+            .when(caseService).delinkCitizenUploadedDocumentFromCase(
+                AUTH_TOKEN,
+                "12345",
+                "00000000-0000-0000-0000-000000000123"
+            );
+
+        RuntimeException runtimeException = assertThrows(
+            RuntimeException.class,
+            () -> caseDocumentController.deleteDocument(
+                AUTH_TOKEN,
+                S2S_TOKEN,
+                "00000000-0000-0000-0000-000000000123"
+            )
+        );
+
+        assertTrue(runtimeException.getMessage().contains("test failure"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/citizen/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/citizen/CaseServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.EventRequestData;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
@@ -123,6 +124,7 @@ import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.TEST_UUID;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.YES;
 import static uk.gov.hmcts.reform.prl.enums.CaseEvent.C100_REQUEST_SUPPORT;
 import static uk.gov.hmcts.reform.prl.enums.CaseEvent.CITIZEN_CASE_UPDATE;
+import static uk.gov.hmcts.reform.prl.enums.CaseEvent.CITIZEN_UPLOADED_DOCUMENT;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.No;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.Yes;
 import static uk.gov.hmcts.reform.prl.services.ServiceOfApplicationService.PERSONAL_SERVICE_SERVED_BY_BAILIFF;
@@ -1904,6 +1906,74 @@ public class CaseServiceTest {
         assertTrue(CollectionUtils.isEmpty(citizenDocumentsManagement.getCitizenNotifications()));
     }
 
+
+    @Test
+    void testDelinkCitizenUploadedDocumentFromCase() {
+        String documentId = "00000000-0000-0000-0000-000000000123";
+        Element<QuarantineLegalDoc> documentToDelink = Element.<QuarantineLegalDoc>builder()
+            .id(UUID.fromString(documentId))
+            .value(QuarantineLegalDoc.builder()
+                       .citizenQuarantineDocument(Document.builder()
+                                                        .documentUrl("http://dm-store:8080/documents/" + documentId)
+                                                        .build())
+                       .build())
+            .build();
+        Element<QuarantineLegalDoc> retainedDocument = Element.<QuarantineLegalDoc>builder()
+            .id(UUID.fromString("00000000-0000-0000-0000-000000000124"))
+            .value(QuarantineLegalDoc.builder()
+                       .citizenQuarantineDocument(Document.builder()
+                                                        .documentUrl(
+                                                            "http://dm-store:8080/documents/00000000-0000-0000-0000-000000000124")
+                                                        .build())
+                       .build())
+            .build();
+        CaseData caseDataWithCitizenDocuments = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .citizenQuarantineDocsList(List.of(documentToDelink, retainedDocument))
+                                           .build())
+            .build();
+        CaseDetails caseDetailsWithCitizenDocuments = CaseDetails.builder()
+            .id(Long.parseLong(CASE_ID))
+            .data(Map.of())
+            .build();
+        EventRequestData eventRequestData = EventRequestData.builder().build();
+        StartEventResponse startEventResponse = StartEventResponse.builder()
+            .caseDetails(caseDetailsWithCitizenDocuments)
+            .build();
+        CaseDataContent caseDataContent = CaseDataContent.builder().build();
+
+        when(idamClient.getUserInfo(AUTH_TOKEN)).thenReturn(UserInfo.builder().uid("test-user-id").build());
+        when(coreCaseDataService.eventRequest(CITIZEN_UPLOADED_DOCUMENT, "test-user-id")).thenReturn(eventRequestData);
+        when(coreCaseDataService.startUpdate(AUTH_TOKEN, eventRequestData, CASE_ID, false)).thenReturn(startEventResponse);
+        when(objectMapper.convertValue(caseDetailsWithCitizenDocuments.getData(), CaseData.class))
+            .thenReturn(caseDataWithCitizenDocuments);
+        when(coreCaseDataService.createCaseDataContent(
+            Mockito.eq(startEventResponse),
+            Mockito.<Map<String, Object>>argThat(caseDataMap -> {
+                List<Element<QuarantineLegalDoc>> updatedDocuments =
+                    (List<Element<QuarantineLegalDoc>>) caseDataMap.get("citizenQuarantineDocsList");
+
+                return updatedDocuments.size() == 1
+                    && updatedDocuments.getFirst().getId().equals(retainedDocument.getId());
+            })
+        )).thenReturn(caseDataContent);
+
+        caseService.delinkCitizenUploadedDocumentFromCase(AUTH_TOKEN, CASE_ID, documentId);
+
+        Mockito.verify(coreCaseDataService).eventRequest(CITIZEN_UPLOADED_DOCUMENT, "test-user-id");
+        Mockito.verify(coreCaseDataService).startUpdate(AUTH_TOKEN, eventRequestData, CASE_ID, false);
+        Mockito.verify(coreCaseDataService).createCaseDataContent(
+            Mockito.eq(startEventResponse),
+            Mockito.<Map<String, Object>>argThat(caseDataMap -> {
+                List<Element<QuarantineLegalDoc>> updatedDocuments =
+                    (List<Element<QuarantineLegalDoc>>) caseDataMap.get("citizenQuarantineDocsList");
+
+                return updatedDocuments.size() == 1
+                    && updatedDocuments.getFirst().getId().equals(retainedDocument.getId());
+            })
+        );
+        Mockito.verify(coreCaseDataService).submitUpdate(AUTH_TOKEN, eventRequestData, caseDataContent, CASE_ID, false);
+    }
 
     @Test
      void testUpdateCitizenRaFlagsWithNullPartyDetailsMeta() {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] the `enable_keep_helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


[FPVTL-2707](https://tools.hmcts.net/jira/browse/FPVTL-2707)



### Change description ###
Added new logic to delink a document from case when removing a document from portal.
Added tests to cover the logic.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
