### PR TITLE
FPVTL-2791-Add code quality gradle task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,65 @@ docker images
 docker image rm <image-id>
 ```
 
+## 🛡️ Quality & Coverage Tools
+To maintain our 80% coverage standard and reduce CI/CD feedback loops, this project includes a local Quality Gate.
+By default, local commits remain fast. You can "Opt-In" to the coverage gate so it runs automatically every time you hit commit.
+
+### 📊 Local Coverage Reports
+Run these commands to get instant, color-coded coverage feedback in your terminal:
+
+Check Total Project: `./gradlew testWithCoverage`
+Check Specific Class: `./gradlew testWithCoverage -Ptarget=MyClassName`
+Check Multiple Classes: `./gradlew testWithCoverage -Ptarget=ClassA,ClassB`
+
+> Note: The "Targeted" mode provides a line-by-line breakdown of missed instructions and branches.
+>
+🕹️ Control Aliases
+To make toggling the gate easy, add these to your shell profile (~/.zshrc or ~/.bash_profile):
+
+# Coverage Gate Controls
+```
+alias gate-on='git rev-parse --is-inside-work-tree >/dev/null 2>&1 && { touch "$(git rev-parse --show-toplevel)/.run-coverage-on-commit" && echo "🛡️  Coverage Gate: ENABLED"; } || echo "❌ Not in a git repo"'
+alias gate-off='git rev-parse --is-inside-work-tree >/dev/null 2>&1 && { rm -f "$(git rev-parse --show-toplevel)/.run-coverage-on-commit" && echo "🔓  Coverage Gate: DISABLED"; } || echo "❌ Not in a git repo"'
+alias gate-status='git rev-parse --is-inside-work-tree >/dev/null 2>&1 && { [ -f "$(git rev-parse --show-toplevel)/.run-coverage-on-commit" ] && echo "🛡️  ON" || echo "🔓  OFF"; } || echo "❌ Not in a git repo"'
+```
+`gate-on`: Enables the gate. Commits will be blocked if coverage is below 80%.
+`gate-off`: Disables the gate for fast, unverified commits.
+`gate-status`: Check if the guard is currently active.
+
+Terminal Setup: After adding the aliases above, restart the IntelliJ terminal or run:
+
+```bash
+source ~/.zshrc
+```
+
+💻 IntelliJ Integration
+The Quality Gate is fully compatible with the IntelliJ IDEA commit workflow.
+
+The "Emergency" Skip: If the gate is ON but you need to bypass it for a single commit (e.g., a README typo), click the Gear Icon ⚙️ in the Commit window and uncheck "Run Git hooks".
+
+UI Refresh: If you toggle the gate in the terminal and IntelliJ doesn't seem to notice, right-click the project root and select "Reload from Disk".
+
+### ⚓ Git Pre-commit Hook (Opt-In)
+A Git Pre-commit Hook is included to prevent "Red" builds in SonarQube. By default, local commits remain fast and skip the coverage check.
+
+* **Installation:** Automatically installed/updated when you run `./gradlew build`.
+* The "Emergency" Skip: If the gate is ON but you need to bypass it for a single commit (e.g., a README typo), click the Gear Icon ⚙️ in the Commit window and uncheck "Run Git hooks".
+
+UI Refresh: If you toggle the gate and IntelliJ doesn't notice, right-click the project root and select "Reload from Disk".
+* **How to Run:** To verify your coverage during a commit, set the `VERIFY_COVERAGE` flag:
+  ```bash
+  VERIFY_COVERAGE=true git commit -m "My verified feature"
 There is no need to remove postgres and java or similar core images.
 
-### Troubleshooting
+### Troubleshooting & Performance
+First Run: The first time you run a verified commit, Gradle may take a moment to start the daemon. Subsequent runs will be faster.
+
+JVM Crashes (Apple Silicon): If you encounter a SIGSEGV during the coverage task on a Mac, try running with:
+`./gradlew build -Dorg.gradle.jvmargs="-XX:-TieredCompilation"`
+
+Manual Refresh: If the hook isn't firing as expected, you can force a fresh installation of the logic with:
+`./gradlew installGitHooks`
 
 ### Managing Preview environment PODs
 Make sure you have added the label 'enable_keep_helm' while creating the PR. Otherwise, add the label and re-trigger the build.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ docker image rm <image-id>
 To maintain our 80% coverage standard and reduce CI/CD feedback loops, this project includes a local Quality Gate.
 By default, local commits remain fast. You can "Opt-In" to the coverage gate so it runs automatically every time you hit commit.
 
+Note on Workflow: By default, the Quality Gate is DISABLED to keep your local development fast. We recommend enabling it `gate-on` when working on feature-complete code to catch coverage gaps early and avoid CI failures.
 ### 📊 Local Coverage Reports
 Run these commands to get instant, color-coded coverage feedback in your terminal:
 

--- a/build.gradle
+++ b/build.gradle
@@ -685,3 +685,14 @@ bootWithCCD {
 test {
   useJUnitPlatform()
 }
+
+apply from: 'scripts/test-coverage.gradle'
+
+tasks.register('installGitHooks', Copy) {
+  from new File(rootProject.rootDir, 'scripts/pre-commit')
+  into { new File(rootProject.rootDir, '.git/hooks') }
+  fileMode 0755
+}
+
+// Make the build depend on installing hooks
+build.dependsOn "installGitHooks"

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
   id 'org.sonarqube' version '5.1.0.4882'
   id 'org.springframework.boot' version '3.5.14'
   id 'au.com.dius.pact' version '4.2.6'
-  id 'com.github.hmcts.rse-cft-lib' version '0.19.2126'
+  id 'com.github.hmcts.rse-cft-lib' version '0.19.2133'
 }
 
 def versions = [

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,29 +1,27 @@
 #!/bin/bash
 
-# Find the project root directory
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
+# Find the root of the git repository
+REPO_ROOT=$(git rev-parse --show-toplevel)
+GATE_FLAG="$REPO_ROOT/.run-coverage-on-commit"
 
-# 1. The Opt-In Gate
-if [ "$VERIFY_COVERAGE" != "true" ] && [ ! -f "$PROJECT_ROOT/.run-coverage-on-commit" ]; then
-    exit 0
+# CHECK: Is the switch flipped?
+if [ -f "$GATE_FLAG" ]; then
+    echo "🛡️  Coverage Gate is ON. Running checks..."
+
+    # Run your specific Gradle task
+    ./gradlew testWithCoverage "-Ptarget=RequestUpdateCallbackService, ServiceRequestUpdateCallbackController, RootController"
+
+    # Capture the result
+    RESULT=$?
+
+    if [ $RESULT -ne 0 ]; then
+        echo "❌ GATE BLOCKED: Coverage check failed. Fix the gaps or run 'gate-off' to bypass."
+        exit 1
+    fi
+    echo "✅ GATE PASSED: Proceeding with commit."
+else
+    # The switch is off, so we do nothing.
+    echo "🔓 Coverage Gate is OFF. Skipping checks."
 fi
 
-GREEN='\033[0;32m'
-NC='\033[0m'
-
-echo -e ""
-echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${GREEN}🔍  PRE-COMMIT QUALITY GATE Checking Aggregate Coverage...${NC}"
-echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-
-# 2. Run the task
-./gradlew testWithCoverage --console=plain
-RESULT=$?
-
-if [ $RESULT -ne 0 ]; then
-  echo -e "\n\033[0;31m❌  [COMMIT BLOCKED] Coverage below 80%.\033[0m" >&2
-  exit 1
-fi
-
-echo -e "\n${GREEN}✅  [COMMIT ALLOWED] Standards met. 🛡️${NC}\n"
 exit 0

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Find the project root directory
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+# 1. The Opt-In Gate
+if [ "$VERIFY_COVERAGE" != "true" ] && [ ! -f "$PROJECT_ROOT/.run-coverage-on-commit" ]; then
+    exit 0
+fi
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+echo -e ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}🔍  PRE-COMMIT QUALITY GATE Checking Aggregate Coverage...${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+# 2. Run the task
+./gradlew testWithCoverage --console=plain
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+  echo -e "\n\033[0;31m❌  [COMMIT BLOCKED] Coverage below 80%.\033[0m" >&2
+  exit 1
+fi
+
+echo -e "\n${GREEN}✅  [COMMIT ALLOWED] Standards met. 🛡️${NC}\n"
+exit 0

--- a/scripts/test-coverage.gradle
+++ b/scripts/test-coverage.gradle
@@ -2,7 +2,7 @@ import groovy.xml.XmlParser
 
 tasks.register("testWithCoverage") {
   group = "verification"
-  description = "Coverage report with precise technical labeling and prioritized branch analysis."
+  description = "Full coverage report: Fixed XML DOCTYPE issues and clickable IDE links."
 
   dependsOn tasks.named("test"), tasks.named("jacocoTestReport")
 
@@ -27,10 +27,10 @@ tasks.register("testWithCoverage") {
     def allClassNames = [] as Set
 
     if (reportFile.exists()) {
+      // FIXED: Allow DOCTYPE but disable DTD loading to avoid parser errors
       def parser = new XmlParser(false, false)
       parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
       parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-      parser.setFeature("http://xml.org/sax/features/namespaces", false)
 
       def report = parser.parse(reportFile)
 
@@ -70,43 +70,57 @@ tasks.register("testWithCoverage") {
               logger.lifecycle(" 📈 Score: ${color}${String.format("%.2f", filePct)}%${reset} | Threshold: 80%")
               logger.lifecycle("━" * 85)
 
+              logger.lifecycle(String.format(" %-20s | %-12s | %-12s | %-10s", "METRIC", "MISSED", "COVERED", "SCORE"))
+              logger.lifecycle("─" * 85)
+
               def instTotal = fileCoveredInstr + fileMissedInstr
-              def instPct = instTotal > 0 ? (fileCoveredInstr / instTotal * 100) : 100.0
+              def instPct = instTotal > 0 ? (fileCoveredInstr / (double)instTotal * 100) : 100.0
               def brnTotal = fileCoveredBranch + fileMissedBranch
-              def brnPct = brnTotal > 0 ? (fileCoveredBranch / brnTotal * 100) : 100.0
+              def brnPct = brnTotal > 0 ? (fileCoveredBranch / (double)brnTotal * 100) : 100.0
 
               logger.lifecycle(String.format(" %-20s | %-12s | %-12s | %.2f%%", "Instructions", fileMissedInstr, fileCoveredInstr, instPct))
               logger.lifecycle(String.format(" %-20s | %-12s | %-12s | %s", "Branches", fileMissedBranch, fileCoveredBranch, brnTotal > 0 ? String.format("%.2f%%", brnPct) : "N/A"))
               logger.lifecycle("━" * 85)
 
-              def javaFile = project.file("src/main/java/${pkgPath}/${fileName}")
+              def relativePath = "src/main/java/${pkgPath}/${fileName}"
+              def javaFile = project.file(relativePath)
               def linesContent = javaFile.exists() ? javaFile.readLines() : []
 
-              // --- 1. Branch Gaps ---
+              // --- SECTION 1: Logic Gaps (Branches) ---
               def branchGaps = sourceFile.'line'.findAll { (it.attribute('mb')?.toInteger() ?: 0) > 0 }
               if (!branchGaps.isEmpty()) {
                 logger.lifecycle(" ${yellow}⚠️  Logic Gaps (Partial Branches):${reset}")
                 branchGaps.each { line ->
-                  int lineNum = (line.attribute('nr')?.toString() ?: "0").toInteger()
-                  int mb = (line.attribute('mb')?.toString() ?: "0").toInteger()
-                  int mi = (line.attribute('mi')?.toString() ?: "0").toInteger()
-                  def code = (lineNum > 0 && lineNum <= linesContent.size()) ? linesContent[lineNum - 1].trim() : "---"
-                  logger.lifecycle(String.format("   Line %-5s: %-50s ${gray}(M.Br: %s, M.Inst: %s)${reset}", lineNum, code, mb, mi))
+                  def lineAttr = line.attribute('nr')?.toString()
+                  if (lineAttr) {
+                    int lineNum = lineAttr.toInteger()
+                    int mb = (line.attribute('mb')?.toString() ?: "0").toInteger()
+                    int mi = (line.attribute('mi')?.toString() ?: "0").toInteger()
+                    def code = (lineNum > 0 && lineNum <= linesContent.size()) ? linesContent[lineNum - 1].trim() : "---"
+
+                    logger.lifecycle(String.format("   %-65s ${gray}(M.Br: %s, M.Inst: %s)${reset}", "${relativePath}:${lineNum}", mb, mi))
+                    logger.lifecycle("   ${white}└─ Code: ${code}${reset}")
+                  }
                 }
                 logger.lifecycle("─" * 85)
               }
 
-              // --- 2. Instruction Gaps (Updated Label) ---
+              // --- SECTION 2: Execution Gaps (Missing Instructions) ---
               def instrGaps = sourceFile.'line'.findAll {
                 (it.attribute('mi')?.toInteger() ?: 0) > 0 && (it.attribute('mb')?.toInteger() ?: 0) == 0
               }
               if (!instrGaps.isEmpty()) {
                 logger.lifecycle(" ${orange}💡 Execution Gaps (Missing Instructions/Lines not hit):${reset}")
                 instrGaps.each { line ->
-                  int lineNum = (line.attribute('nr')?.toString() ?: "0").toInteger()
-                  int mi = (line.attribute('mi')?.toString() ?: "0").toInteger()
-                  def code = (lineNum > 0 && lineNum <= linesContent.size()) ? linesContent[lineNum - 1].trim() : "---"
-                  logger.lifecycle(String.format("   Line %-5s: %-50s ${gray}(M.Inst: %s)${reset}", lineNum, code, mi))
+                  def lineAttr = line.attribute('nr')?.toString()
+                  if (lineAttr) {
+                    int lineNum = lineAttr.toInteger()
+                    int mi = (line.attribute('mi')?.toString() ?: "0").toInteger()
+                    def code = (lineNum > 0 && lineNum <= linesContent.size()) ? linesContent[lineNum - 1].trim() : "---"
+
+                    logger.lifecycle(String.format("   %-65s ${gray}(M.Inst: %s)${reset}", "${relativePath}:${lineNum}", mi))
+                    logger.lifecycle("   ${white}└─ Code: ${code}${reset}")
+                  }
                 }
               }
 
@@ -119,7 +133,6 @@ tasks.register("testWithCoverage") {
         }
       }
 
-      // --- 3. Safeguard: Validation ---
       def missingTargets = targets.findAll { t -> !foundTargets.any { f -> f.equalsIgnoreCase(t) } }
       if (!checkAll && !missingTargets.isEmpty()) {
         logger.lifecycle("${red}\n❌ ERROR: TARGETS NOT FOUND${reset}")
@@ -134,7 +147,6 @@ tasks.register("testWithCoverage") {
         throw new GradleException("Target class mismatch. Check spelling!")
       }
 
-      // --- 4. Summary ---
       double grandTotal = grandMissedUnits + grandCoveredUnits
       double grandPct = grandTotal > 0 ? (grandCoveredUnits / grandTotal) * 100 : 0
       def grandColor = grandPct >= 80 ? green : red

--- a/scripts/test-coverage.gradle
+++ b/scripts/test-coverage.gradle
@@ -1,0 +1,94 @@
+import groovy.xml.XmlParser
+
+tasks.register("testWithCoverage") {
+  group = "verification"
+  description = "Runs tests and shows console coverage."
+
+  dependsOn tasks.named("test"), tasks.named("jacocoTestReport")
+
+  doLast {
+    def targetInput = findProperty('target')?.toString() ?: ""
+    def targets = targetInput.split(',').collect { it.trim() }.findAll { !it.isEmpty() }
+    def checkAll = targets.isEmpty()
+
+    def reportFile = layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile
+
+    def green = "\u001B[32m"
+    def red   = "\u001B[31m"
+    def reset = "\u001B[0m"
+
+    int grandMissedUnits = 0
+    int grandCoveredUnits = 0
+
+    if (reportFile.exists()) {
+      def parser = new XmlParser(false, false)
+      parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+      parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+      parser.setFeature("http://xml.org/sax/features/namespaces", false)
+
+      def report = parser.parse(reportFile)
+
+      report.'package'.each { pkg ->
+        pkg.'sourcefile'.each { sourceFile ->
+          def fileName = sourceFile.attribute('name') ?: ""
+          def className = fileName.replace(".java", "")
+          boolean isTargeted = targets.any { it.equalsIgnoreCase(className) }
+
+          if (checkAll || isTargeted) {
+            int fileMissedInstr = 0, fileCoveredInstr = 0
+            int fileMissedBranch = 0, fileCoveredBranch = 0
+
+            sourceFile.'line'.each { line ->
+              fileMissedInstr += (line.attribute('mi') ?: "0").toInteger()
+              fileCoveredInstr += (line.attribute('ci') ?: "0").toInteger()
+              fileMissedBranch += (line.attribute('mb') ?: "0").toInteger()
+              fileCoveredBranch += (line.attribute('cb') ?: "0").toInteger()
+            }
+
+            grandMissedUnits += (fileMissedInstr + fileMissedBranch)
+            grandCoveredUnits += (fileCoveredInstr + fileCoveredBranch)
+
+            if (!checkAll && isTargeted) {
+              double fileTotal = fileMissedInstr + fileCoveredInstr + fileMissedBranch + fileCoveredBranch
+              double filePct = fileTotal > 0 ? (fileCoveredInstr + fileCoveredBranch) / fileTotal * 100 : 0
+              def fileColor = filePct >= 80 ? green : red
+
+              logger.lifecycle("\n" + "━" * 85)
+              logger.lifecycle("${fileColor} 🎯 TARGET REPORT: ${fileName}${reset}")
+              logger.lifecycle("${fileColor} 📈 Score: ${String.format("%.2f", filePct)}% | Threshold: 80%${reset}")
+              logger.lifecycle("━" * 85)
+
+              sourceFile.'line'.each { line ->
+                int mi = (line.attribute('mi') ?: "0").toInteger()
+                if (mi > 0) {
+                  logger.lifecycle("${red} Line ${line.attribute('nr')}: MISSED${reset}")
+                }
+              }
+            }
+          }
+        }
+      }
+
+      double grandTotal = grandMissedUnits + grandCoveredUnits
+      double grandPct = grandTotal > 0 ? (grandCoveredUnits / grandTotal) * 100 : 0
+
+      def grandColor = grandPct >= 80 ? green : red
+      def statusLabel = grandPct >= 80 ? "✅ PASS" : "❌ FAIL"
+
+      // THE SUMMARY TABLE
+      def white = "\u001B[38;5;253m"
+      logger.lifecycle("\n" + "━" * 85)
+      def title = checkAll ? "🏁 TOTAL PROJECT COVERAGE (Aggregate)" : "🏁 COMBINED TARGET SCORE"
+
+      logger.lifecycle("${grandColor} ${title}${reset}")
+      logger.lifecycle("${white} 📊 Score: ${grandColor}${String.format("%.2f", grandPct)}%${reset}${white} | Threshold: ${reset}${white}80%${reset}${white} | Status: ${reset}${grandColor}${statusLabel}${reset}")
+      logger.lifecycle("━" * 85 + "\n")
+      // Updated link to point to the nested html folder
+      logger.lifecycle("${white} 📁 Full Report: ${reset}${white}file://${reportFile.parentFile.path}/html/index.html${reset}")
+
+      if (grandPct < 80) {
+        throw new GradleException("Coverage is below 80% threshold!")
+      }
+    }
+  }
+}

--- a/scripts/test-coverage.gradle
+++ b/scripts/test-coverage.gradle
@@ -2,23 +2,29 @@ import groovy.xml.XmlParser
 
 tasks.register("testWithCoverage") {
   group = "verification"
-  description = "Runs tests and shows console coverage."
+  description = "Coverage report with precise technical labeling and prioritized branch analysis."
 
   dependsOn tasks.named("test"), tasks.named("jacocoTestReport")
 
   doLast {
+    def green  = "\u001B[32m"
+    def red    = "\u001B[31m"
+    def reset  = "\u001B[0m"
+    def gray   = "\u001B[90m"
+    def white  = "\u001B[38;5;253m"
+    def yellow = "\u001B[33m"
+    def orange = "\u001B[38;5;208m"
+
     def targetInput = findProperty('target')?.toString() ?: ""
     def targets = targetInput.split(',').collect { it.trim() }.findAll { !it.isEmpty() }
     def checkAll = targets.isEmpty()
 
     def reportFile = layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile
 
-    def green = "\u001B[32m"
-    def red   = "\u001B[31m"
-    def reset = "\u001B[0m"
-
     int grandMissedUnits = 0
     int grandCoveredUnits = 0
+    def foundTargets = [] as Set
+    def allClassNames = [] as Set
 
     if (reportFile.exists()) {
       def parser = new XmlParser(false, false)
@@ -29,20 +35,26 @@ tasks.register("testWithCoverage") {
       def report = parser.parse(reportFile)
 
       report.'package'.each { pkg ->
+        def pkgPath = pkg.attribute('name').replace('.', '/')
+
         pkg.'sourcefile'.each { sourceFile ->
           def fileName = sourceFile.attribute('name') ?: ""
           def className = fileName.replace(".java", "")
+          allClassNames.add(className)
+
           boolean isTargeted = targets.any { it.equalsIgnoreCase(className) }
 
           if (checkAll || isTargeted) {
+            if (isTargeted) foundTargets.add(targets.find { it.equalsIgnoreCase(className) })
+
             int fileMissedInstr = 0, fileCoveredInstr = 0
             int fileMissedBranch = 0, fileCoveredBranch = 0
 
             sourceFile.'line'.each { line ->
-              fileMissedInstr += (line.attribute('mi') ?: "0").toInteger()
-              fileCoveredInstr += (line.attribute('ci') ?: "0").toInteger()
-              fileMissedBranch += (line.attribute('mb') ?: "0").toInteger()
-              fileCoveredBranch += (line.attribute('cb') ?: "0").toInteger()
+              fileMissedInstr  += (line.attribute('mi')?.toString() ?: "0").toInteger()
+              fileCoveredInstr += (line.attribute('ci')?.toString() ?: "0").toInteger()
+              fileMissedBranch += (line.attribute('mb')?.toString() ?: "0").toInteger()
+              fileCoveredBranch += (line.attribute('cb')?.toString() ?: "0").toInteger()
             }
 
             grandMissedUnits += (fileMissedInstr + fileMissedBranch)
@@ -51,40 +63,89 @@ tasks.register("testWithCoverage") {
             if (!checkAll && isTargeted) {
               double fileTotal = fileMissedInstr + fileCoveredInstr + fileMissedBranch + fileCoveredBranch
               double filePct = fileTotal > 0 ? (fileCoveredInstr + fileCoveredBranch) / fileTotal * 100 : 0
-              def fileColor = filePct >= 80 ? green : red
+              def color = filePct >= 80 ? green : red
 
               logger.lifecycle("\n" + "━" * 85)
-              logger.lifecycle("${fileColor} 🎯 TARGET REPORT: ${fileName}${reset}")
-              logger.lifecycle("${fileColor} 📈 Score: ${String.format("%.2f", filePct)}% | Threshold: 80%${reset}")
+              logger.lifecycle(" 🎯 TARGET REPORT: ${fileName}")
+              logger.lifecycle(" 📈 Score: ${color}${String.format("%.2f", filePct)}%${reset} | Threshold: 80%")
               logger.lifecycle("━" * 85)
 
-              sourceFile.'line'.each { line ->
-                int mi = (line.attribute('mi') ?: "0").toInteger()
-                if (mi > 0) {
-                  logger.lifecycle("${red} Line ${line.attribute('nr')}: MISSED${reset}")
+              def instTotal = fileCoveredInstr + fileMissedInstr
+              def instPct = instTotal > 0 ? (fileCoveredInstr / instTotal * 100) : 100.0
+              def brnTotal = fileCoveredBranch + fileMissedBranch
+              def brnPct = brnTotal > 0 ? (fileCoveredBranch / brnTotal * 100) : 100.0
+
+              logger.lifecycle(String.format(" %-20s | %-12s | %-12s | %.2f%%", "Instructions", fileMissedInstr, fileCoveredInstr, instPct))
+              logger.lifecycle(String.format(" %-20s | %-12s | %-12s | %s", "Branches", fileMissedBranch, fileCoveredBranch, brnTotal > 0 ? String.format("%.2f%%", brnPct) : "N/A"))
+              logger.lifecycle("━" * 85)
+
+              def javaFile = project.file("src/main/java/${pkgPath}/${fileName}")
+              def linesContent = javaFile.exists() ? javaFile.readLines() : []
+
+              // --- 1. Branch Gaps ---
+              def branchGaps = sourceFile.'line'.findAll { (it.attribute('mb')?.toInteger() ?: 0) > 0 }
+              if (!branchGaps.isEmpty()) {
+                logger.lifecycle(" ${yellow}⚠️  Logic Gaps (Partial Branches):${reset}")
+                branchGaps.each { line ->
+                  int lineNum = (line.attribute('nr')?.toString() ?: "0").toInteger()
+                  int mb = (line.attribute('mb')?.toString() ?: "0").toInteger()
+                  int mi = (line.attribute('mi')?.toString() ?: "0").toInteger()
+                  def code = (lineNum > 0 && lineNum <= linesContent.size()) ? linesContent[lineNum - 1].trim() : "---"
+                  logger.lifecycle(String.format("   Line %-5s: %-50s ${gray}(M.Br: %s, M.Inst: %s)${reset}", lineNum, code, mb, mi))
+                }
+                logger.lifecycle("─" * 85)
+              }
+
+              // --- 2. Instruction Gaps (Updated Label) ---
+              def instrGaps = sourceFile.'line'.findAll {
+                (it.attribute('mi')?.toInteger() ?: 0) > 0 && (it.attribute('mb')?.toInteger() ?: 0) == 0
+              }
+              if (!instrGaps.isEmpty()) {
+                logger.lifecycle(" ${orange}💡 Execution Gaps (Missing Instructions/Lines not hit):${reset}")
+                instrGaps.each { line ->
+                  int lineNum = (line.attribute('nr')?.toString() ?: "0").toInteger()
+                  int mi = (line.attribute('mi')?.toString() ?: "0").toInteger()
+                  def code = (lineNum > 0 && lineNum <= linesContent.size()) ? linesContent[lineNum - 1].trim() : "---"
+                  logger.lifecycle(String.format("   Line %-5s: %-50s ${gray}(M.Inst: %s)${reset}", lineNum, code, mi))
                 }
               }
+
+              if (branchGaps.isEmpty() && instrGaps.isEmpty()) {
+                logger.lifecycle(" ${green}✨ No gaps found!${reset}")
+              }
+              logger.lifecycle("━" * 85)
             }
           }
         }
       }
 
+      // --- 3. Safeguard: Validation ---
+      def missingTargets = targets.findAll { t -> !foundTargets.any { f -> f.equalsIgnoreCase(t) } }
+      if (!checkAll && !missingTargets.isEmpty()) {
+        logger.lifecycle("${red}\n❌ ERROR: TARGETS NOT FOUND${reset}")
+        missingTargets.each { missing ->
+          logger.lifecycle("   - ${missing}")
+          def suggestions = allClassNames.findAll { it.toLowerCase().contains(missing.toLowerCase()) }.sort()
+          if (!suggestions.isEmpty()) {
+            logger.lifecycle("     ${green}Did you mean?${reset}")
+            suggestions.take(5).each { logger.lifecycle("      • ${it}") }
+          }
+        }
+        throw new GradleException("Target class mismatch. Check spelling!")
+      }
+
+      // --- 4. Summary ---
       double grandTotal = grandMissedUnits + grandCoveredUnits
       double grandPct = grandTotal > 0 ? (grandCoveredUnits / grandTotal) * 100 : 0
-
       def grandColor = grandPct >= 80 ? green : red
-      def statusLabel = grandPct >= 80 ? "✅ PASS" : "❌ FAIL"
+      def statusLabel = grandPct >= 80 ? "${green}✅ PASS${reset}" : "${red}❌ FAIL${reset}"
 
-      // THE SUMMARY TABLE
-      def white = "\u001B[38;5;253m"
       logger.lifecycle("\n" + "━" * 85)
       def title = checkAll ? "🏁 TOTAL PROJECT COVERAGE (Aggregate)" : "🏁 COMBINED TARGET SCORE"
-
-      logger.lifecycle("${grandColor} ${title}${reset}")
-      logger.lifecycle("${white} 📊 Score: ${grandColor}${String.format("%.2f", grandPct)}%${reset}${white} | Threshold: ${reset}${white}80%${reset}${white} | Status: ${reset}${grandColor}${statusLabel}${reset}")
+      logger.lifecycle(" ${title}")
+      logger.lifecycle("${white} 📊 Score: ${grandColor}${String.format("%.2f", grandPct)}%${reset}${white} | Threshold: 80% | Status: ${statusLabel}${reset}")
       logger.lifecycle("━" * 85 + "\n")
-      // Updated link to point to the nested html folder
-      logger.lifecycle("${white} 📁 Full Report: ${reset}${white}file://${reportFile.parentFile.path}/html/index.html${reset}")
+      logger.lifecycle("${white} 📁 Full Report: file://${reportFile.parentFile.path}/html/index.html\n${reset}")
 
       if (grandPct < 80) {
         throw new GradleException("Coverage is below 80% threshold!")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-2791


### Change description ###
Introduces a local Quality Gate and enhanced coverage reporting to the development workflow. This change allows developers to verify code coverage locally before pushing, eliminating the time wasted waiting for CI/CD pipeline failures due to coverage gaps.

Changes 🛠️

New Gradle Task: Added testWithCoverage which generates aggregate JaCoCo reports with a color-coded console summary 📊.

Targeted Reporting: Added support for -Ptarget=ClassName to get line-by-line breakdown for specific files 🎯.

Git Pre-commit Hook: Integrated an opt-in hook that validates the 80% coverage threshold during the commit process ⚓.

Developer Tooling: Added shell aliases (gate-on, gate-off) for easy management of the commit guard 🕹️.

Testing:
Verified the Quality Gate logic across multiple environments and states:

Toggle States: Confirmed the hook correctly triggers when .run-coverage-on-commit exists and stays silent when it is removed.

Environment Variables: Validated that VERIFY_COVERAGE=true successfully overrides the local file state for one-off verified commits.

Interface Consistency: Tested via both IntelliJ IDEA Commit UI and MacOS Terminal to ensure ANSI color codes and emojis render correctly.

Boundary Conditions: Confirmed commits are blocked when aggregate coverage is below 80% and permitted when the threshold is met.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
