### PR TITLE
FPVTL-2862: Remove review documents data if document is removed

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalControllerAboutToSubmitIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalControllerAboutToSubmitIntegrationTest.java
@@ -151,9 +151,7 @@ public class DocumentRemovalControllerAboutToSubmitIntegrationTest {
         MvcResult result = mockMvc.perform(buildRequest("draft-order-and-message.json"))
             .andExpect(status().isOk())
             .andExpect(jsonPath(DOCUMENT_REMOVAL_DOCUMENT_TO_REMOVE).doesNotExist())
-            .andExpect(jsonPath("$.data.draftOrderCollection", hasSize(1)))
-            .andExpect(jsonPath("$.data.draftOrderCollection[0].value.orderType").exists())
-            .andExpect(jsonPath("$.data.draftOrderCollection[0].value.orderDocument").doesNotExist())
+            .andExpect(jsonPath("$.data.draftOrderCollection").isEmpty())
             .andExpect(jsonPath("$.data.messages[0].value.internalMessageAttachDocs").isEmpty())
             .andExpect(jsonPath("$.data.messages[0].value.messageIdentifier").value("79a658dd-b0ad-40e2-af7a-267a329a793c"))
             .andReturn();

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalController.java
@@ -107,6 +107,7 @@ public class DocumentRemovalController {
         log.info("Document removal submitted callback received for case id: {}", caseDetails.getId());
 
         documentRemovalService.deleteDocument(caseDetails);
+        documentRemovalService.executePostSubmittedActions(callbackRequest);
 
         return SubmittedCallbackResponse.builder()
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/DocumentRemovalService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/DocumentRemovalService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.prl.models.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.prl.models.common.dynamic.DynamicListElement;
@@ -12,6 +13,8 @@ import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.DocumentRemovalWrapper;
 import uk.gov.hmcts.reform.prl.services.DeleteDocumentService;
 import uk.gov.hmcts.reform.prl.services.SystemUserService;
+import uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction.DocumentRemovalAboutToSubmitAction;
+import uk.gov.hmcts.reform.prl.services.documentremoval.submittedaction.DocumentRemovalSubmittedAction;
 import uk.gov.hmcts.reform.prl.utils.CaseUtils;
 
 import java.io.IOException;
@@ -32,6 +35,8 @@ public class DocumentRemovalService {
     private final DocumentRemover documentRemover;
     private final DeleteDocumentService deleteDocumentService;
     private final SystemUserService systemUserService;
+    private final List<DocumentRemovalAboutToSubmitAction> aboutToSubmitActions;
+    private final List<DocumentRemovalSubmittedAction> submittedActions;
 
     private static final DateTimeFormatter UPLOAD_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm");
 
@@ -85,6 +90,10 @@ public class DocumentRemovalService {
         // Cannot remove DOCUMENT_REMOVAL_CASE_DOCUMENTS as the selected document id is needed in the
         // submitted callback to delete the document from cdam
 
+        caseDetails.setData(updatedCaseData);
+        CaseData caseDataUpdated = CaseUtils.getCaseData(caseDetails, objectMapper);
+        aboutToSubmitActions.forEach(action -> action.onAboutToSubmit(caseDataUpdated, updatedCaseData));
+
         return updatedCaseData;
     }
 
@@ -97,6 +106,10 @@ public class DocumentRemovalService {
         String authToken = systemUserService.getSysUserToken();
         log.info("Deleting document with id {} from document store", documentId);
         deleteDocumentService.deleteDocument(authToken, documentId);
+    }
+
+    public void executePostSubmittedActions(CallbackRequest request) {
+        submittedActions.forEach(action -> action.onSubmitted(request));
     }
 
     private String formatSelectDocumentLabel(Document caseDocument) {

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DocumentRemovalAboutToSubmitAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DocumentRemovalAboutToSubmitAction.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+
+import java.util.Map;
+
+public interface DocumentRemovalAboutToSubmitAction {
+
+    void onAboutToSubmit(CaseData caseData, Map<String, Object> caseDataUpdated);
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdater.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.prl.models.DraftOrder;
+import uk.gov.hmcts.reform.prl.models.Element;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Optional.ofNullable;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DRAFT_ORDER_COLLECTION;
+
+@Service
+@Slf4j
+public class DraftOrderUpdater implements DocumentRemovalAboutToSubmitAction {
+
+    @Override
+    public void onAboutToSubmit(CaseData caseData, Map<String, Object> caseDataUpdated) {
+        List<Element<DraftOrder>> draftOrderCollection = ofNullable(caseData.getDraftOrderCollection())
+            .orElse(new ArrayList<>());
+        int draftOrderCount = draftOrderCollection.size();
+
+        draftOrderCollection.removeIf(draftOrderElement -> draftOrderElement.getValue().getOrderDocument() == null);
+
+        if (draftOrderCount != draftOrderCollection.size()) {
+            log.info("Case ID {}: Draft order collection size before {} size after {}", caseData.getId(),
+                     draftOrderCount, draftOrderCollection.size());
+            caseDataUpdated.put(DRAFT_ORDER_COLLECTION, draftOrderCollection);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdater.java
@@ -23,7 +23,9 @@ public class DraftOrderUpdater implements DocumentRemovalAboutToSubmitAction {
             .orElse(new ArrayList<>());
         int draftOrderCount = draftOrderCollection.size();
 
-        draftOrderCollection.removeIf(draftOrderElement -> draftOrderElement.getValue().getOrderDocument() == null);
+        // Remove the draft order element if both the English and Welsh documents are no longer present
+        draftOrderCollection.removeIf(draftOrderElement -> draftOrderElement.getValue().getOrderDocument() == null
+            && draftOrderElement.getValue().getOrderDocumentWelsh() == null);
 
         if (draftOrderCount != draftOrderCollection.size()) {
             log.info("Case ID {}: Draft order collection size before {} size after {}", caseData.getId(),

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/ReviewDocumentUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/ReviewDocumentUpdater.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+import uk.gov.hmcts.reform.prl.services.reviewdocument.ReviewDocumentService;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewDocumentUpdater implements DocumentRemovalAboutToSubmitAction {
+
+    private final ReviewDocumentService reviewDocumentService;
+
+    @Override
+    public void onAboutToSubmit(CaseData caseData, Map<String, Object> caseDataUpdated) {
+        reviewDocumentService.removeReviewDocumentWithMissingDocument(caseData, caseDataUpdated);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/submittedaction/DocumentRemovalSubmittedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/submittedaction/DocumentRemovalSubmittedAction.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.submittedaction;
+
+
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+
+public interface DocumentRemovalSubmittedAction {
+
+    void onSubmitted(CallbackRequest callbackRequest);
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/submittedaction/ReviewDocumentTaskAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/submittedaction/ReviewDocumentTaskAction.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.submittedaction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+import uk.gov.hmcts.reform.prl.services.reviewdocument.ReviewDocumentService;
+import uk.gov.hmcts.reform.prl.utils.CaseUtils;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewDocumentTaskAction implements DocumentRemovalSubmittedAction {
+    private final ReviewDocumentService reviewDocumentService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onSubmitted(CallbackRequest callbackRequest) {
+        CaseData caseData = CaseUtils.getCaseData(callbackRequest.getCaseDetails(), objectMapper);
+        CaseData caseDataBefore = CaseUtils.getCaseData(callbackRequest.getCaseDetailsBefore(), objectMapper);
+
+        if (reviewDocumentService.hasDocumentsToBeReviewed(caseDataBefore)
+            && !reviewDocumentService.hasDocumentsToBeReviewed(caseData)) {
+            reviewDocumentService.triggerAllDocsReviewedEvent(caseData);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/reviewdocument/ReviewDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/reviewdocument/ReviewDocumentService.java
@@ -131,6 +131,13 @@ public class ReviewDocumentService {
     public static final String SEND_AND_REPLY_URL = "/trigger/sendOrReplyToMessages/sendOrReplyToMessages1";
     public static final String SEND_AND_REPLY_MESSAGE_LABEL = "\">Send and reply to messages</a>";
 
+    private record ReviewDocument(
+        List<Element<QuarantineLegalDoc>> quarantineDocs,
+        UserDetails userDetails,
+        String userType,
+        String quarantineDocList
+    ) {}
+
     public List<DynamicListElement> fetchDocumentDynamicListElements(CaseData caseData) {
         List<DynamicListElement> dynamicListElements = new ArrayList<>();
         //solicitor
@@ -306,43 +313,7 @@ public class ReviewDocumentService {
         if (YesNoNotSure.no.equals(caseData.getReviewDocuments().getReviewDecisionYesOrNo())
             || YesNoNotSure.yes.equals(caseData.getReviewDocuments().getReviewDecisionYesOrNo())) {
 
-            List<ReviewDocument> reviewDocs = List.of(
-                //solicitor uploaded docs
-                new ReviewDocument(
-                    caseData.getDocumentManagementDetails().getLegalProfQuarantineDocsList(),
-                    UserDetails.builder().roles(List.of(Roles.SOLICITOR.getValue())).build(),
-                    SOLICITOR,
-                    LEGAL_PROF_QUARANTINE_DOCS_LIST
-                ),
-                //cafcass uploaded docs
-                new ReviewDocument(
-                    caseData.getDocumentManagementDetails().getCafcassQuarantineDocsList(),
-                    UserDetails.builder().roles(List.of(CAFCASS)).build(),
-                    CAFCASS,
-                    CAFCASS_QUARANTINE_DOCS_LIST
-                ),
-                //LA uploaded docs
-                new ReviewDocument(
-                    caseData.getDocumentManagementDetails().getLocalAuthorityQuarantineDocsList(),
-                    UserDetails.builder().roles(List.of(LOCAL_AUTHORITY)).build(),
-                    LOCAL_AUTHORITY,
-                    LOCAL_AUTHORITY_QUARANTINE_DOCS_LIST
-                ),
-                //court staff uploaded docs
-                new ReviewDocument(
-                    caseData.getDocumentManagementDetails().getCourtStaffQuarantineDocsList(),
-                    UserDetails.builder().roles(List.of(Roles.COURT_ADMIN.getValue())).build(),
-                    COURT_STAFF,
-                    COURT_STAFF_QUARANTINE_DOCS_LIST
-                ),
-                //citizen uploaded docs
-                new ReviewDocument(
-                    caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList(),
-                    UserDetails.builder().roles(List.of(Roles.CITIZEN.getValue())).build(),
-                    CITIZEN,
-                    CITIZEN_QUARANTINE_DOCS_LIST
-                )
-            );
+            List<ReviewDocument> reviewDocs = createReviewDocumentList(caseData);
 
             for (ReviewDocument reviewDocument : reviewDocs) {
                 if (null != reviewDocument.quarantineDocs) {
@@ -505,14 +476,18 @@ public class ReviewDocumentService {
             .uploaderRole(BULK_SCAN);
     }
 
-    public ResponseEntity<SubmittedCallbackResponse> getReviewResult(CaseData caseData) {
-        if (CollectionUtils.isEmpty(caseData.getDocumentManagementDetails().getLegalProfQuarantineDocsList())
-            && (CollectionUtils.isEmpty(caseData.getDocumentManagementDetails().getCourtStaffQuarantineDocsList()))
-            && CollectionUtils.isEmpty(caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList())
-            && (CollectionUtils.isEmpty(caseData.getDocumentManagementDetails().getLocalAuthorityQuarantineDocsList()))
-            && CollectionUtils.isEmpty(caseData.getDocumentManagementDetails().getCafcassQuarantineDocsList())
-            && CollectionUtils.isEmpty(caseData.getDocumentManagementDetails().getCourtNavQuarantineDocumentList())
-            && CollectionUtils.isEmpty(caseData.getScannedDocuments())) {
+    public boolean hasDocumentsToBeReviewed(CaseData caseData) {
+        return CollectionUtils.isNotEmpty(caseData.getDocumentManagementDetails().getLegalProfQuarantineDocsList())
+            || CollectionUtils.isNotEmpty(caseData.getDocumentManagementDetails().getCourtStaffQuarantineDocsList())
+            || CollectionUtils.isNotEmpty(caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList())
+            || CollectionUtils.isNotEmpty(caseData.getDocumentManagementDetails().getLocalAuthorityQuarantineDocsList())
+            || CollectionUtils.isNotEmpty(caseData.getDocumentManagementDetails().getCafcassQuarantineDocsList())
+            || CollectionUtils.isNotEmpty(caseData.getDocumentManagementDetails().getCourtNavQuarantineDocumentList())
+            || CollectionUtils.isNotEmpty(caseData.getScannedDocuments());
+    }
+
+    public void triggerAllDocsReviewedEvent(CaseData caseData) {
+        if (!hasDocumentsToBeReviewed(caseData)) {
             StartAllTabsUpdateDataContent startAllTabsUpdateDataContent = allTabService.getStartUpdateForSpecificEvent(
                 String.valueOf(
                     caseData.getId()),
@@ -527,8 +502,12 @@ public class ReviewDocumentService {
                 startAllTabsUpdateDataContent.eventRequestData(),
                 caseDataUpdated
             );
-
         }
+    }
+
+    public ResponseEntity<SubmittedCallbackResponse> getReviewResult(CaseData caseData) {
+        triggerAllDocsReviewedEvent(caseData);
+
         if (YesNoNotSure.yes.equals(caseData.getReviewDocuments().getReviewDecisionYesOrNo())) {
             return ResponseEntity.ok(SubmittedCallbackResponse.builder()
                                          .confirmationHeader(DOCUMENT_SUCCESSFULLY_REVIEWED)
@@ -692,11 +671,64 @@ public class ReviewDocumentService {
         manageDocumentsService.deleteDocumentById(documentId);
     }
 
-    private record ReviewDocument(
-        List<Element<QuarantineLegalDoc>> quarantineDocs,
-        UserDetails userDetails,
-        String userType,
-        String quarantineDocList
-    ) {
+    public void removeReviewDocumentWithMissingDocument(CaseData caseData, Map<String, Object> caseDataUpdated) {
+        List<ReviewDocument> reviewDocs = createReviewDocumentList(caseData);
+
+        reviewDocs.stream()
+            .filter(reviewDocument -> isNotEmpty(reviewDocument.quarantineDocs))
+            .forEach(reviewDocument -> {
+                List<Element<QuarantineLegalDoc>> quarantineLegalDocs = reviewDocument.quarantineDocs();
+                boolean removed = quarantineLegalDocs.removeIf(e -> {
+                    var legalDoc = e.getValue();
+                    Document document = manageDocumentsService.getQuarantineDocumentForUploader(
+                        legalDoc.getUploaderRole(),
+                        legalDoc
+                    );
+                    return document == null;
+                });
+                if (removed) {
+                    caseDataUpdated.put(reviewDocument.quarantineDocList, quarantineLegalDocs);
+                }
+            });
+    }
+
+    private List<ReviewDocument> createReviewDocumentList(CaseData caseData) {
+        return List.of(
+            //solicitor uploaded docs
+            new ReviewDocument(
+                caseData.getDocumentManagementDetails().getLegalProfQuarantineDocsList(),
+                UserDetails.builder().roles(List.of(Roles.SOLICITOR.getValue())).build(),
+                SOLICITOR,
+                LEGAL_PROF_QUARANTINE_DOCS_LIST
+            ),
+            //cafcass uploaded docs
+            new ReviewDocument(
+                caseData.getDocumentManagementDetails().getCafcassQuarantineDocsList(),
+                UserDetails.builder().roles(List.of(CAFCASS)).build(),
+                CAFCASS,
+                CAFCASS_QUARANTINE_DOCS_LIST
+            ),
+            //LA uploaded docs
+            new ReviewDocument(
+                caseData.getDocumentManagementDetails().getLocalAuthorityQuarantineDocsList(),
+                UserDetails.builder().roles(List.of(LOCAL_AUTHORITY)).build(),
+                LOCAL_AUTHORITY,
+                LOCAL_AUTHORITY_QUARANTINE_DOCS_LIST
+            ),
+            //court staff uploaded docs
+            new ReviewDocument(
+                caseData.getDocumentManagementDetails().getCourtStaffQuarantineDocsList(),
+                UserDetails.builder().roles(List.of(Roles.COURT_ADMIN.getValue())).build(),
+                COURT_STAFF,
+                COURT_STAFF_QUARANTINE_DOCS_LIST
+            ),
+            //citizen uploaded docs
+            new ReviewDocument(
+                caseData.getDocumentManagementDetails().getCitizenQuarantineDocsList(),
+                UserDetails.builder().roles(List.of(Roles.CITIZEN.getValue())).build(),
+                CITIZEN,
+                CITIZEN_QUARANTINE_DOCS_LIST
+            )
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalControllerTest.java
@@ -101,7 +101,8 @@ class DocumentRemovalControllerTest {
         SubmittedCallbackResponse response = controller.submitted(auth, s2s, callbackRequest);
 
         assertNotNull(response);
-        verify(documentRemovalService).deleteDocument(any());
+        verify(documentRemovalService).deleteDocument(any(CaseDetails.class));
+        verify(documentRemovalService).executePostSubmittedActions(any(CallbackRequest.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/DocumentRemovalServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/DocumentRemovalServiceTest.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.prl.models.common.dynamic.DynamicList;
 import uk.gov.hmcts.reform.prl.models.common.dynamic.DynamicListElement;
@@ -15,6 +15,8 @@ import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.DocumentRemovalWrapper;
 import uk.gov.hmcts.reform.prl.services.DeleteDocumentService;
 import uk.gov.hmcts.reform.prl.services.SystemUserService;
+import uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction.DocumentRemovalAboutToSubmitAction;
+import uk.gov.hmcts.reform.prl.services.documentremoval.submittedaction.DocumentRemovalSubmittedAction;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -28,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,8 +47,11 @@ class DocumentRemovalServiceTest {
     private DeleteDocumentService deleteDocumentService;
     @Mock
     private SystemUserService systemUserService;
+    @Mock
+    private DocumentRemovalAboutToSubmitAction documentRemovalAboutToSubmitAction;
+    @Mock
+    private DocumentRemovalSubmittedAction documentRemovalSubmittedAction;
 
-    @InjectMocks
     private DocumentRemovalService documentRemovalService;
 
     @Mock private CaseDetails caseDetails;
@@ -55,6 +61,10 @@ class DocumentRemovalServiceTest {
 
     @BeforeEach
     void setUp() {
+        documentRemovalService = new DocumentRemovalService(objectMapper, documentRetriever, documentRemover,
+                                                            deleteDocumentService, systemUserService,
+                                                            List.of(documentRemovalAboutToSubmitAction),
+                                                            List.of(documentRemovalSubmittedAction));
         document = Document.builder()
             .documentUrl("http://someserver/doc1")
             .documentFileName("file1.pdf")
@@ -132,6 +142,8 @@ class DocumentRemovalServiceTest {
         assertFalse(result.containsKey("documentToRemove"));
         assertFalse(result.containsKey("documentRemovalConfirmOptions"));
         assertEquals("someValue", result.get("someKey"));
+
+        verify(documentRemovalAboutToSubmitAction).onAboutToSubmit(any(CaseData.class), anyMap());
     }
 
     @Test
@@ -142,5 +154,13 @@ class DocumentRemovalServiceTest {
         documentRemovalService.deleteDocument(caseDetails);
 
         verify(deleteDocumentService).deleteDocument("token", "doc1");
+    }
+
+    @Test
+    void testExecuteSubmittedActions() {
+        CallbackRequest callbackRequest = mock(CallbackRequest.class);
+        documentRemovalService.executePostSubmittedActions(callbackRequest);
+
+        verify(documentRemovalSubmittedAction).onSubmitted(any(CallbackRequest.class));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdatedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdatedTest.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.hmcts.reform.prl.models.DraftOrder;
 import uk.gov.hmcts.reform.prl.models.Element;
 import uk.gov.hmcts.reform.prl.models.documents.Document;
@@ -12,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -55,19 +59,16 @@ class DraftOrderUpdatedTest {
                 .isEqualTo(orderId);
     }
 
-    @Test
-    void shouldNotUpdateMapIfNoDraftOrdersRemoved() {
-        DraftOrder draftOrderWithDoc = mock(DraftOrder.class);
-        when(draftOrderWithDoc.getOrderDocument()).thenReturn(Document.builder().build());
-
+    @ParameterizedTest
+    @MethodSource("provideDraftOrdersWithDocuments")
+    void shouldNotUpdateMapIfDocumentRemains(DraftOrder draftOrder) {
         List<Element<DraftOrder>> draftOrders = new ArrayList<>();
         UUID orderId = UUID.randomUUID();
-        draftOrders.add(new Element<>(orderId, draftOrderWithDoc));
+        draftOrders.add(new Element<>(orderId, draftOrder));
 
         CaseData caseData = CaseData.builder()
             .draftOrderCollection(draftOrders)
             .build();
-
 
         Map<String, Object> caseDataUpdated = new HashMap<>();
 
@@ -75,6 +76,33 @@ class DraftOrderUpdatedTest {
 
         // Map should not be updated since nothing was removed
         assertThat(caseDataUpdated).isEmpty();
+    }
+
+    private static Stream<Arguments> provideDraftOrdersWithDocuments() {
+        return Stream.of(
+            Arguments.of(draftOrderWithEnglishOnlyDoc()),
+            Arguments.of(draftOrderWithWelshOnlyDoc()),
+            Arguments.of(draftOrderWithEnglishAndWelshDoc())
+        );
+    }
+
+    private static DraftOrder draftOrderWithEnglishOnlyDoc() {
+        DraftOrder draftOrder = mock(DraftOrder.class);
+        when(draftOrder.getOrderDocument()).thenReturn(Document.builder().build());
+        return draftOrder;
+    }
+
+    private static DraftOrder draftOrderWithWelshOnlyDoc() {
+        DraftOrder draftOrder = mock(DraftOrder.class);
+        when(draftOrder.getOrderDocumentWelsh()).thenReturn(Document.builder().build());
+        return draftOrder;
+    }
+
+    private static DraftOrder draftOrderWithEnglishAndWelshDoc() {
+        DraftOrder draftOrder = mock(DraftOrder.class);
+        when(draftOrder.getOrderDocument()).thenReturn(Document.builder().build());
+        when(draftOrder.getOrderDocumentWelsh()).thenReturn(Document.builder().build());
+        return draftOrder;
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdatedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdatedTest.java
@@ -1,0 +1,108 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.prl.models.DraftOrder;
+import uk.gov.hmcts.reform.prl.models.Element;
+import uk.gov.hmcts.reform.prl.models.documents.Document;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DRAFT_ORDER_COLLECTION;
+
+class DraftOrderUpdatedTest {
+
+    private DraftOrderUpdater draftOrderUpdater;
+
+    @BeforeEach
+    void setUp() {
+        draftOrderUpdater = new DraftOrderUpdater();
+    }
+
+    @Test
+    void shouldRemoveDraftOrdersWithNullOrderDocument() {
+        DraftOrder draftOrderWithDoc = mock(DraftOrder.class);
+        when(draftOrderWithDoc.getOrderDocument()).thenReturn(Document.builder().build());
+
+        DraftOrder draftOrderWithoutDoc = mock(DraftOrder.class);
+        when(draftOrderWithoutDoc.getOrderDocument()).thenReturn(null);
+
+        List<Element<DraftOrder>> draftOrders = new ArrayList<>();
+        UUID orderId = UUID.randomUUID();
+        draftOrders.add(new Element<>(orderId, draftOrderWithDoc));
+        draftOrders.add(new Element<>(UUID.randomUUID(), draftOrderWithoutDoc));
+
+        CaseData caseData = mock(CaseData.class);
+        when(caseData.getDraftOrderCollection()).thenReturn(draftOrders);
+        when(caseData.getId()).thenReturn(123L);
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Only the draft order with a non-null document should remain
+        List<Element<DraftOrder>> updated = (List<Element<DraftOrder>>) caseDataUpdated.get(DRAFT_ORDER_COLLECTION);
+        assertThat(updated).singleElement()
+                .extracting(Element::getId)
+                .isEqualTo(orderId);
+    }
+
+    @Test
+    void shouldNotUpdateMapIfNoDraftOrdersRemoved() {
+        DraftOrder draftOrderWithDoc = mock(DraftOrder.class);
+        when(draftOrderWithDoc.getOrderDocument()).thenReturn(Document.builder().build());
+
+        List<Element<DraftOrder>> draftOrders = new ArrayList<>();
+        UUID orderId = UUID.randomUUID();
+        draftOrders.add(new Element<>(orderId, draftOrderWithDoc));
+
+        CaseData caseData = CaseData.builder()
+            .draftOrderCollection(draftOrders)
+            .build();
+
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Map should not be updated since nothing was removed
+        assertThat(caseDataUpdated).isEmpty();
+    }
+
+    @Test
+    void shouldHandleEmptyDraftOrderCollection() {
+        List<Element<DraftOrder>> draftOrders = new ArrayList<>();
+
+        CaseData caseData = CaseData.builder()
+            .draftOrderCollection(draftOrders)
+            .build();
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Map should not be updated
+        assertThat(caseDataUpdated).isEmpty();
+    }
+
+    @Test
+    void shouldHandleNullDraftOrderCollection() {
+        CaseData caseData = CaseData.builder()
+            .build();
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Map should not be updated
+        assertThat(caseDataUpdated).isEmpty();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/ReviewDocumentUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/ReviewDocumentUpdaterTest.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+import uk.gov.hmcts.reform.prl.services.reviewdocument.ReviewDocumentService;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewDocumentUpdaterTest {
+    @Mock
+    private ReviewDocumentService reviewDocumentService;
+    @InjectMocks
+    private ReviewDocumentUpdater reviewDocumentUpdater;
+
+    @Test
+    void shouldUpdateReviewDocument() {
+        CaseData caseData = CaseData.builder().build();
+        Map<String, Object> caseDataUpdated = Map.of();
+        reviewDocumentUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+        verify(reviewDocumentService).removeReviewDocumentWithMissingDocument(caseData, caseDataUpdated);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/submittedaction/ReviewDocumentTaskActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/submittedaction/ReviewDocumentTaskActionTest.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.submittedaction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+import uk.gov.hmcts.reform.prl.services.reviewdocument.ReviewDocumentService;
+import uk.gov.hmcts.reform.prl.utils.CaseUtils;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewDocumentTaskActionTest {
+
+    @Mock
+    private ReviewDocumentService reviewDocumentService;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private CallbackRequest callbackRequest;
+    @Mock
+    private CaseDetails caseDetails;
+    @Mock
+    private CaseDetails caseDetailsBefore;
+    @Mock
+    private CaseData caseData;
+    @Mock
+    private CaseData caseDataBefore;
+
+    @InjectMocks
+    private ReviewDocumentTaskAction reviewDocumentTaskAction;
+
+    @Test
+    void shouldTriggerEventWhenDocsReviewed() {
+        try (MockedStatic<CaseUtils> mockedCaseUtils = org.mockito.Mockito.mockStatic(CaseUtils.class)) {
+            mockCaseData(mockedCaseUtils);
+            when(reviewDocumentService.hasDocumentsToBeReviewed(caseDataBefore)).thenReturn(true);
+            when(reviewDocumentService.hasDocumentsToBeReviewed(caseData)).thenReturn(false);
+
+            reviewDocumentTaskAction.onSubmitted(callbackRequest);
+
+            verify(reviewDocumentService).triggerAllDocsReviewedEvent(caseData);
+        }
+    }
+
+    @Test
+    void shouldNotTriggerEventWhenDocsStillToBeReviewed() {
+        try (MockedStatic<CaseUtils> mockedCaseUtils = org.mockito.Mockito.mockStatic(CaseUtils.class)) {
+            mockCaseData(mockedCaseUtils);
+            when(reviewDocumentService.hasDocumentsToBeReviewed(caseDataBefore)).thenReturn(true);
+            when(reviewDocumentService.hasDocumentsToBeReviewed(caseData)).thenReturn(true);
+
+            reviewDocumentTaskAction.onSubmitted(callbackRequest);
+
+            verify(reviewDocumentService, never()).triggerAllDocsReviewedEvent(any());
+        }
+    }
+
+    @Test
+    void shouldNotTriggerEventWhenNoDocsToBeReviewedBefore() {
+        try (MockedStatic<CaseUtils> mockedCaseUtils = org.mockito.Mockito.mockStatic(CaseUtils.class)) {
+            mockCaseData(mockedCaseUtils);
+            when(reviewDocumentService.hasDocumentsToBeReviewed(caseDataBefore)).thenReturn(false);
+
+            reviewDocumentTaskAction.onSubmitted(callbackRequest);
+
+            verify(reviewDocumentService, never()).triggerAllDocsReviewedEvent(any());
+        }
+    }
+
+    private void mockCaseData(MockedStatic<CaseUtils> mockedCaseUtils) {
+        mockedCaseUtils.when(() -> CaseUtils.getCaseData(caseDetails, objectMapper)).thenReturn(caseData);
+        mockedCaseUtils.when(() -> CaseUtils.getCaseData(caseDetailsBefore, objectMapper)).thenReturn(caseDataBefore);
+
+        when(callbackRequest.getCaseDetails()).thenReturn(caseDetails);
+        when(callbackRequest.getCaseDetailsBefore()).thenReturn(caseDetailsBefore);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/reviewdocument/ReviewDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/reviewdocument/ReviewDocumentServiceTest.java
@@ -67,6 +67,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -820,7 +824,7 @@ public class ReviewDocumentServiceTest {
         Assert.assertNotNull(caseDataMap.get("bulkScannedDocListDocTab"));
         Assert.assertEquals(1, bulkScannedDocListDocTab.size());
         Assert.assertNotNull(bulkScannedDocListDocTab.get(0).getValue().getUrl());
-        Assert.assertNull(bulkScannedDocListDocTab.get(0).getValue().getCategoryId());
+        assertNull(bulkScannedDocListDocTab.get(0).getValue().getCategoryId());
         Assert.assertEquals("123", bulkScannedDocListDocTab.get(0).getValue().getControlNumber());
         Assert.assertEquals("EXREF", bulkScannedDocListDocTab.get(0).getValue().getExceptionRecordReference());
     }
@@ -866,7 +870,7 @@ public class ReviewDocumentServiceTest {
         List<Element<QuarantineLegalDoc>> confidentialDocs =
             (List<Element<QuarantineLegalDoc>>) caseDataMap.get(CONFIDENTIAL_DOCUMENTS);
         Assert.assertNotNull(confidentialDocs.get(0).getValue().getUrl());
-        Assert.assertNull(confidentialDocs.get(0).getValue().getCategoryId());
+        assertNull(confidentialDocs.get(0).getValue().getCategoryId());
         Assert.assertEquals("123", confidentialDocs.get(0).getValue().getControlNumber());
         Assert.assertEquals("EXREF", confidentialDocs.get(0).getValue().getExceptionRecordReference());
 
@@ -1872,9 +1876,110 @@ public class ReviewDocumentServiceTest {
     }
 
     private List<Element<QuarantineLegalDoc>> documentListWithRemovedDocument() {
-        return List.of(element(UUID.randomUUID(), QuarantineLegalDoc.builder()
+        return new ArrayList<>(List.of(element(UUID.randomUUID(), QuarantineLegalDoc.builder()
             .uploaderRole(LEGAL_PROFESSIONAL)
             .document(null)
-            .build()));
+            .build())));
+    }
+
+    private static List<Element<QuarantineLegalDoc>> document() {
+        return new ArrayList<>(List.of(element(UUID.randomUUID(), QuarantineLegalDoc.builder()
+            .uploaderRole(LEGAL_PROFESSIONAL)
+            .document(Document.builder().build())
+            .build())));
+    }
+
+    @Test
+    public void givenDocumentRemoved_thenRemoveFromReviewDocuments() {
+        CaseData caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .legalProfQuarantineDocsList(documentListWithRemovedDocument())
+                                           .cafcassQuarantineDocsList(documentListWithRemovedDocument())
+                                           .localAuthorityQuarantineDocsList(documentListWithRemovedDocument())
+                                           .courtStaffQuarantineDocsList(documentListWithRemovedDocument())
+                                           .citizenQuarantineDocsList(documentListWithRemovedDocument())
+                                           .courtNavQuarantineDocumentList(documentListWithRemovedDocument())
+                                           .build())
+            .build();
+
+        doCallRealMethod().when(manageDocumentsService).getQuarantineDocumentForUploader(any(), any());
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+        reviewDocumentService.removeReviewDocumentWithMissingDocument(caseData, caseDataUpdated);
+        assertEquals(5, caseDataUpdated.size());
+        for (Object value : caseDataUpdated.values()) {
+            assertTrue(value instanceof List);
+            assertTrue(((List<?>) value).isEmpty());
+        }
+    }
+
+    @Test
+    public void givenDocumentTobeReviewed_whenHasDocumentsToBeReviewed_thenReturnsTrue() {
+        List<Element<QuarantineLegalDoc>> documents = document();
+
+        CaseData caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .legalProfQuarantineDocsList(documents)
+                                           .build())
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+
+        caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .cafcassQuarantineDocsList(documents)
+                                           .build())
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+
+        caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .courtStaffQuarantineDocsList(documents)
+                                           .build())
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+
+        caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .citizenQuarantineDocsList(documents)
+                                           .build())
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+
+        caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .localAuthorityQuarantineDocsList(documents)
+                                           .build())
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+
+        caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder()
+                                           .courtNavQuarantineDocumentList(documents)
+                                           .build())
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+
+        List<Element<ScannedDocument>> scannedDocuments = List.of(element(ScannedDocument.builder().build()));
+        caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder().build())
+            .scannedDocuments(scannedDocuments)
+            .build();
+
+        assertTrue(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
+    }
+
+    @Test
+    public void givenDocumentTobeReviewed_whenHasDocumentsToBeReviewed_thenReturnsFalse() {
+        CaseData caseData = CaseData.builder()
+            .documentManagementDetails(DocumentManagementDetails.builder().build())
+            .build();
+
+        assertFalse(reviewDocumentService.hasDocumentsToBeReviewed(caseData));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-2862


### Change description ###
When a document that is a "document to be reviewed" is removed then we need to handle
- removing the whole data structure from the Documents to be removed tab
- removing any Review documents task when there are no other documents to be reviewed


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
