### PR TITLE
FPVTL-2869: Remove draft order data if document has been removed

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalControllerAboutToSubmitIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/prl/controllers/documentremoval/DocumentRemovalControllerAboutToSubmitIntegrationTest.java
@@ -151,9 +151,7 @@ public class DocumentRemovalControllerAboutToSubmitIntegrationTest {
         MvcResult result = mockMvc.perform(buildRequest("draft-order-and-message.json"))
             .andExpect(status().isOk())
             .andExpect(jsonPath(DOCUMENT_REMOVAL_DOCUMENT_TO_REMOVE).doesNotExist())
-            .andExpect(jsonPath("$.data.draftOrderCollection", hasSize(1)))
-            .andExpect(jsonPath("$.data.draftOrderCollection[0].value.orderType").exists())
-            .andExpect(jsonPath("$.data.draftOrderCollection[0].value.orderDocument").doesNotExist())
+            .andExpect(jsonPath("$.data.draftOrderCollection").isEmpty())
             .andExpect(jsonPath("$.data.messages[0].value.internalMessageAttachDocs").isEmpty())
             .andExpect(jsonPath("$.data.messages[0].value.messageIdentifier").value("79a658dd-b0ad-40e2-af7a-267a329a793c"))
             .andReturn();

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdater.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.prl.models.DraftOrder;
+import uk.gov.hmcts.reform.prl.models.Element;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Optional.ofNullable;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DRAFT_ORDER_COLLECTION;
+
+@Service
+@Slf4j
+public class DraftOrderUpdater implements DocumentRemovalAboutToSubmitAction {
+
+    @Override
+    public void onAboutToSubmit(CaseData caseData, Map<String, Object> caseDataUpdated) {
+        List<Element<DraftOrder>> draftOrderCollection = ofNullable(caseData.getDraftOrderCollection())
+            .orElse(new ArrayList<>());
+        int draftOrderCount = draftOrderCollection.size();
+
+        draftOrderCollection.removeIf(draftOrderElement -> draftOrderElement.getValue().getOrderDocument() == null);
+
+        if (draftOrderCount != draftOrderCollection.size()) {
+            log.info("Case ID {}: Draft order collection size before {} size after {}", caseData.getId(),
+                     draftOrderCount, draftOrderCollection.size());
+            caseDataUpdated.put(DRAFT_ORDER_COLLECTION, draftOrderCollection);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdatedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/documentremoval/postabouttosubmitaction/DraftOrderUpdatedTest.java
@@ -1,0 +1,108 @@
+package uk.gov.hmcts.reform.prl.services.documentremoval.postabouttosubmitaction;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.prl.models.DraftOrder;
+import uk.gov.hmcts.reform.prl.models.Element;
+import uk.gov.hmcts.reform.prl.models.documents.Document;
+import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.DRAFT_ORDER_COLLECTION;
+
+class DraftOrderUpdatedTest {
+
+    private DraftOrderUpdater draftOrderUpdater;
+
+    @BeforeEach
+    void setUp() {
+        draftOrderUpdater = new DraftOrderUpdater();
+    }
+
+    @Test
+    void shouldRemoveDraftOrdersWithNullOrderDocument() {
+        DraftOrder draftOrderWithDoc = mock(DraftOrder.class);
+        when(draftOrderWithDoc.getOrderDocument()).thenReturn(Document.builder().build());
+
+        DraftOrder draftOrderWithoutDoc = mock(DraftOrder.class);
+        when(draftOrderWithoutDoc.getOrderDocument()).thenReturn(null);
+
+        List<Element<DraftOrder>> draftOrders = new ArrayList<>();
+        UUID orderId = UUID.randomUUID();
+        draftOrders.add(new Element<>(orderId, draftOrderWithDoc));
+        draftOrders.add(new Element<>(UUID.randomUUID(), draftOrderWithoutDoc));
+
+        CaseData caseData = mock(CaseData.class);
+        when(caseData.getDraftOrderCollection()).thenReturn(draftOrders);
+        when(caseData.getId()).thenReturn(123L);
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Only the draft order with a non-null document should remain
+        List<Element<DraftOrder>> updated = (List<Element<DraftOrder>>) caseDataUpdated.get(DRAFT_ORDER_COLLECTION);
+        assertThat(updated).singleElement()
+                .extracting(Element::getId)
+                .isEqualTo(orderId);
+    }
+
+    @Test
+    void shouldNotUpdateMapIfNoDraftOrdersRemoved() {
+        DraftOrder draftOrderWithDoc = mock(DraftOrder.class);
+        when(draftOrderWithDoc.getOrderDocument()).thenReturn(Document.builder().build());
+
+        List<Element<DraftOrder>> draftOrders = new ArrayList<>();
+        UUID orderId = UUID.randomUUID();
+        draftOrders.add(new Element<>(orderId, draftOrderWithDoc));
+
+        CaseData caseData = CaseData.builder()
+            .draftOrderCollection(draftOrders)
+            .build();
+
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Map should not be updated since nothing was removed
+        assertThat(caseDataUpdated).isEmpty();
+    }
+
+    @Test
+    void shouldHandleEmptyDraftOrderCollection() {
+        List<Element<DraftOrder>> draftOrders = new ArrayList<>();
+
+        CaseData caseData = CaseData.builder()
+            .draftOrderCollection(draftOrders)
+            .build();
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Map should not be updated
+        assertThat(caseDataUpdated).isEmpty();
+    }
+
+    @Test
+    void shouldHandleNullDraftOrderCollection() {
+        CaseData caseData = CaseData.builder()
+            .build();
+
+        Map<String, Object> caseDataUpdated = new HashMap<>();
+
+        draftOrderUpdater.onAboutToSubmit(caseData, caseDataUpdated);
+
+        // Map should not be updated
+        assertThat(caseDataUpdated).isEmpty();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-2869


### Change description ###
- When a draft order document is removed then the draft order collection item needs to be removed too


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
