### PR TITLE
FPVTL-2916: Archive respondent C8s

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -60,6 +61,7 @@ import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.APPLICANTS;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C100_CASE_TYPE;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C8_ARCHIVED_DOCUMENTS;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C8_RESP_DRAFT_HINT;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C8_RESP_FINAL_HINT;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C8_RESP_FL401_DRAFT_HINT;
@@ -93,6 +95,7 @@ import static uk.gov.hmcts.reform.prl.services.ConfidentialDetailsChangeHelper.c
 import static uk.gov.hmcts.reform.prl.services.c100respondentsolicitor.C100RespondentSolicitorService.IS_CONFIDENTIAL_DATA_PRESENT;
 import static uk.gov.hmcts.reform.prl.utils.CommonUtils.getPartyResponse;
 import static uk.gov.hmcts.reform.prl.utils.ElementUtils.element;
+import static uk.gov.hmcts.reform.prl.utils.ElementUtils.nullSafeList;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -666,6 +669,23 @@ public class UpdatePartyDetailsService {
         return false;
     }
 
+    private List<Element<Document>> archiveRespondentC8Documents(List<Element<ResponseDocuments>> existingDocuments, CaseData caseData) {
+        List<Element<Document>> archivedDocuments = new ArrayList<>(nullSafeList(caseData.getC8ArchivedDocuments()));
+        nullSafeList(existingDocuments).stream().map(Element::getValue).forEach(responseDocuments -> {
+            if (isNotEmpty(responseDocuments.getRespondentC8Document())) {
+                archivedDocuments.add(
+                    element(UUID.randomUUID(), responseDocuments.getRespondentC8Document()));
+            }
+            if (isNotEmpty(responseDocuments.getRespondentC8DocumentWelsh())) {
+                archivedDocuments.add(
+                    element(UUID.randomUUID(), responseDocuments.getRespondentC8DocumentWelsh()));
+            }
+        });
+        // Set in the case data for the next respondent so we don't lose archived documents between respondents
+        caseData.setC8ArchivedDocuments(archivedDocuments);
+        return archivedDocuments;
+    }
+
     public void populateC8Documents(String authorisation, Map<String, Object> updatedCaseData, CaseData caseData,
                                       Map<String, Object> dataMap, Boolean isDetailsChanged, int partyIndex,
                                       Element<PartyDetails> respondent) {
@@ -676,6 +696,12 @@ public class UpdatePartyDetailsService {
         if (partyIndex >= 0) {
             switch (partyIndex) {
                 case 0:
+                    if (Boolean.TRUE.equals(isDetailsChanged)) {
+                        updatedCaseData.put(
+                            C8_ARCHIVED_DOCUMENTS, archiveRespondentC8Documents(
+                                caseData.getRespondentC8Document().getRespondentAc8Documents(), caseData)
+                        );
+                    }
                     updatedCaseData
                         .put("respondentAc8Documents",getOrCreateC8DocumentList(authorisation, caseData, dataMap,
                                                                                 caseData.getRespondentC8Document()
@@ -684,6 +710,12 @@ public class UpdatePartyDetailsService {
                                                                                 respondent));
                     break;
                 case 1:
+                    if (Boolean.TRUE.equals(isDetailsChanged)) {
+                        updatedCaseData.put(
+                            C8_ARCHIVED_DOCUMENTS, archiveRespondentC8Documents(
+                                caseData.getRespondentC8Document().getRespondentBc8Documents(), caseData)
+                        );
+                    }
                     updatedCaseData
                         .put("respondentBc8Documents",getOrCreateC8DocumentList(authorisation, caseData,
                                                                                 dataMap,
@@ -693,6 +725,12 @@ public class UpdatePartyDetailsService {
                                                                                 respondent));
                     break;
                 case 2:
+                    if (Boolean.TRUE.equals(isDetailsChanged)) {
+                        updatedCaseData.put(
+                            C8_ARCHIVED_DOCUMENTS, archiveRespondentC8Documents(
+                                caseData.getRespondentC8Document().getRespondentCc8Documents(), caseData)
+                        );
+                    }
                     updatedCaseData
                         .put("respondentCc8Documents",getOrCreateC8DocumentList(authorisation, caseData,
                                                                                 dataMap,
@@ -702,6 +740,12 @@ public class UpdatePartyDetailsService {
                                                                                 respondent));
                     break;
                 case 3:
+                    if (Boolean.TRUE.equals(isDetailsChanged)) {
+                        updatedCaseData.put(
+                            C8_ARCHIVED_DOCUMENTS, archiveRespondentC8Documents(
+                                caseData.getRespondentC8Document().getRespondentDc8Documents(), caseData)
+                        );
+                    }
                     updatedCaseData
                         .put("respondentDc8Documents",getOrCreateC8DocumentList(authorisation, caseData,
                                                                                 dataMap,
@@ -711,6 +755,12 @@ public class UpdatePartyDetailsService {
                                                                                 respondent));
                     break;
                 case 4:
+                    if (Boolean.TRUE.equals(isDetailsChanged)) {
+                        updatedCaseData.put(
+                            C8_ARCHIVED_DOCUMENTS, archiveRespondentC8Documents(
+                                caseData.getRespondentC8Document().getRespondentEc8Documents(), caseData)
+                        );
+                    }
                     updatedCaseData
                         .put("respondentEc8Documents",getOrCreateC8DocumentList(authorisation, caseData,
                                                                                 dataMap,
@@ -763,7 +813,7 @@ public class UpdatePartyDetailsService {
                                                                                     .respondentC8DocumentWelsh(
                                                                                         c8FinalWelshDocument)
                                                                                     .build());
-                return getC8DocumentReverseOrderList(c8Documents, newC8Document);
+                return List.of(newC8Document);
             } else {
                 return  c8Documents;
             }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsServiceTest.java
@@ -2360,6 +2360,118 @@ class UpdatePartyDetailsServiceTest {
         assertEquals(Collections.emptyList(), (updatedCaseData.get("respondentBc8Documents")));
     }
 
+    @Test
+    void testPopulateC8DocumentsWhenRespondentChangesFromConfidentialToNonConfidential() {
+        CaseData caseData = CaseData.builder()
+            .caseTypeOfApplication(C100_CASE_TYPE)
+            .state(State.CASE_ISSUED)
+            .respondentC8Document(RespondentC8Document.builder()
+                                     .respondentAc8Documents(List.of(existingResponseDocument()))
+                                     .build())
+            .build();
+        when(manageOrderService.getLoggedInUserType("authToken")).thenReturn("testUser");
+
+        Map<String, Object> updatedCaseData = new HashMap<>();
+        Map<String, Object> dataMap = new HashMap<>();
+
+        updatePartyDetailsService.populateC8Documents(
+            "authToken", updatedCaseData, caseData, dataMap, true, 0, respondent("Respondent A")
+        );
+
+        assertNotNull(updatedCaseData.get("respondentAc8Documents"));
+        assertTrue(((List<?>) updatedCaseData.get("respondentAc8Documents")).isEmpty());
+        assertEquals(1, ((List<?>) updatedCaseData.get("c8ArchivedDocuments")).size());
+        verify(documentGenService, Mockito.never()).generateSingleDocument(anyString(), any(), anyString(),
+                                                                            Mockito.anyBoolean(), anyMap());
+    }
+
+    @Test
+    void testPopulateC8DocumentsWhenRespondentRemainsConfidentialAndDetailsChange() {
+        CaseData caseData = CaseData.builder()
+            .caseTypeOfApplication(C100_CASE_TYPE)
+            .state(State.CASE_ISSUED)
+            .respondentC8Document(RespondentC8Document.builder()
+                                     .respondentAc8Documents(List.of(existingResponseDocument()))
+                                     .build())
+            .build();
+        when(manageOrderService.getLoggedInUserType("authToken")).thenReturn("testUser");
+        when(documentLanguageService.docGenerateLang(caseData)).thenReturn(DocumentLanguage.builder().isGenWelsh(false).build());
+        when(documentGenService.generateSingleDocument(anyString(), any(), anyString(), Mockito.anyBoolean(), anyMap()))
+            .thenReturn(Document.builder().build());
+
+        Map<String, Object> updatedCaseData = new HashMap<>();
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(IS_CONFIDENTIAL_DATA_PRESENT, true);
+
+        updatePartyDetailsService.populateC8Documents(
+            "authToken", updatedCaseData, caseData, dataMap, true, 0, respondent("Respondent A")
+        );
+
+        assertEquals(1, ((List<?>) updatedCaseData.get("respondentAc8Documents")).size());
+        assertEquals(1, ((List<?>) updatedCaseData.get("c8ArchivedDocuments")).size());
+        verify(documentGenService, Mockito.times(1)).generateSingleDocument(anyString(), any(), anyString(),
+                                                                            Mockito.anyBoolean(), anyMap());
+    }
+
+    @Test
+    void testPopulateC8DocumentsWhenRespondentChangesFromNonConfidentialToConfidential() {
+        CaseData caseData = CaseData.builder()
+            .caseTypeOfApplication(C100_CASE_TYPE)
+            .state(State.CASE_ISSUED)
+            .respondentC8Document(RespondentC8Document.builder().build())
+            .build();
+        when(manageOrderService.getLoggedInUserType("authToken")).thenReturn("testUser");
+        when(documentLanguageService.docGenerateLang(caseData)).thenReturn(DocumentLanguage.builder().isGenWelsh(false).build());
+        when(documentGenService.generateSingleDocument(anyString(), any(), anyString(), Mockito.anyBoolean(), anyMap()))
+            .thenReturn(Document.builder().build());
+
+        Map<String, Object> updatedCaseData = new HashMap<>();
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(IS_CONFIDENTIAL_DATA_PRESENT, true);
+
+        updatePartyDetailsService.populateC8Documents(
+            "authToken", updatedCaseData, caseData, dataMap, true, 0, respondent("Respondent A")
+        );
+
+        assertEquals(1, ((List<?>) updatedCaseData.get("respondentAc8Documents")).size());
+        assertEquals(0, ((List<?>) updatedCaseData.get("c8ArchivedDocuments")).size());
+        verify(documentGenService, Mockito.times(1)).generateSingleDocument(anyString(), any(), anyString(),
+                                                                            Mockito.anyBoolean(), anyMap());
+    }
+
+    @Test
+    void testPopulateC8DocumentsWhenTwoRespondentsRemainConfidentialAndBothDetailsChange() {
+        CaseData caseData = CaseData.builder()
+            .caseTypeOfApplication(C100_CASE_TYPE)
+            .state(State.CASE_ISSUED)
+            .respondentC8Document(RespondentC8Document.builder()
+                                     .respondentAc8Documents(List.of(existingResponseDocument()))
+                                     .respondentBc8Documents(List.of(existingResponseDocument()))
+                                     .build())
+            .build();
+        when(manageOrderService.getLoggedInUserType("authToken")).thenReturn("testUser");
+        when(documentLanguageService.docGenerateLang(caseData)).thenReturn(DocumentLanguage.builder().isGenWelsh(false).build());
+        when(documentGenService.generateSingleDocument(anyString(), any(), anyString(), Mockito.anyBoolean(), anyMap()))
+            .thenReturn(Document.builder().build());
+
+        Map<String, Object> updatedCaseData = new HashMap<>();
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(IS_CONFIDENTIAL_DATA_PRESENT, true);
+
+        updatePartyDetailsService.populateC8Documents(
+            "authToken", updatedCaseData, caseData, dataMap, true, 0, respondent("Respondent A")
+        );
+        updatePartyDetailsService.populateC8Documents(
+            "authToken", updatedCaseData, caseData, dataMap, true, 1, respondent("Respondent B")
+        );
+
+        assertEquals(1, ((List<?>) updatedCaseData.get("respondentAc8Documents")).size());
+        assertEquals(1, ((List<?>) updatedCaseData.get("respondentBc8Documents")).size());
+        assertEquals(2, ((List<?>) updatedCaseData.get("c8ArchivedDocuments")).size());
+        verify(documentGenService, Mockito.times(2)).generateSingleDocument(anyString(), any(), anyString(),
+                                                                            Mockito.anyBoolean(), anyMap());
+    }
+
     @ParameterizedTest
     @CsvSource({"PREPARE_FOR_HEARING_CONDUCT_HEARING, 1", "DECISION_OUTCOME, 1", "SUBMITTED_PAID, 0", "CASE_ISSUED, 0", "JUDICIAL_REVIEW, 0" })
     void shouldInvokeGenerateC8DocumentsForApplicantOnlyInHearingStates(State state, int times) throws Exception {
@@ -2731,6 +2843,17 @@ class UpdatePartyDetailsServiceTest {
         List<String> validationErrorList = updatePartyDetailsService.validateUpdatePartyDetails(callbackRequest);
 
         assertTrue(validationErrorList.isEmpty());
+    }
+
+    private Element<ResponseDocuments> existingResponseDocument() {
+        return element(ResponseDocuments.builder()
+                           .dateTimeCreated(LocalDateTime.now())
+                           .respondentC8Document(Document.builder().build())
+                           .build());
+    }
+
+    private Element<PartyDetails> respondent(String label) {
+        return element(PartyDetails.builder().firstName(label).lastName("Test").build());
     }
 
     private Element<PartyDetails> getPartyDetails(String partyName, boolean hasBarrister) {

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsServiceTest.java
@@ -2340,7 +2340,7 @@ class UpdatePartyDetailsServiceTest {
                 PartyDetails.builder().firstName("firstName").lastName("lastName").build())
         );
         assertNotNull(updatedCaseData.get("respondentBc8Documents"));
-        assertEquals(1, ((ArrayList) updatedCaseData.get("respondentBc8Documents")).size());
+        assertEquals(1, ((List<?>) updatedCaseData.get("respondentBc8Documents")).size());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
FPVTL-2916


### Change description ###
 - Before processing, if there is a "change" - we will archive the existing C8s (if any exist).
    - If no more confidentiality, no new one generated
    - If still confidentiality, new copy generated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
