### PR TITLE
FPVTL-2202: Ensure the Other C8s are accessible over the API

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/models/dto/cafcass/CafCassCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/models/dto/cafcass/CafCassCaseData.java
@@ -772,6 +772,9 @@ public class CafCassCaseData {
     private List<uk.gov.hmcts.reform.prl.models.Element<ResponseDocuments>> respondentDc8Documents;
     private List<uk.gov.hmcts.reform.prl.models.Element<ResponseDocuments>> respondentEc8Documents;
 
+    private List<uk.gov.hmcts.reform.prl.models.Element<ResponseDocuments>> otherPartyC8Documents;
+
+
     private uk.gov.hmcts.reform.prl.models.documents.Document specialArrangementsLetter;
     private uk.gov.hmcts.reform.prl.models.documents.Document additionalDocuments;
     private List<uk.gov.hmcts.reform.prl.models.Element<uk.gov.hmcts.reform.prl.models.documents.Document>> additionalDocumentsList;

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataService.java
@@ -543,7 +543,7 @@ public class CafcassCaseDataService {
                 ));
         }
         if (CollectionUtils.isNotEmpty(caseData.getOtherPartyC8Documents())) {
-            caseData.getRespondentEc8Documents().parallelStream().forEach(
+            caseData.getOtherPartyC8Documents().parallelStream().forEach(
                 responseDocumentsElement ->
                     populateRespondentDocument(
                         responseDocumentsElement.getValue().getRespondentC8Document(),

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataService.java
@@ -266,6 +266,7 @@ public class CafcassCaseDataService {
                 .respondentCc8Documents(null)
                 .respondentDc8Documents(null)
                 .respondentEc8Documents(null)
+                .otherPartyC8Documents(null)
                 .c8FormDocumentsUploaded(null)
                 .bundleInformation(null)
                 .otherDocumentsUploaded(null)
@@ -540,6 +541,16 @@ public class CafcassCaseDataService {
                     CONFIDENTIAL,
                     otherDocsList
                 ));
+        }
+        if (CollectionUtils.isNotEmpty(caseData.getOtherPartyC8Documents())) {
+            caseData.getRespondentEc8Documents().parallelStream().forEach(
+                responseDocumentsElement ->
+                    populateRespondentDocument(
+                        responseDocumentsElement.getValue().getRespondentC8Document(),
+                        responseDocumentsElement.getValue().getRespondentC8DocumentWelsh(),
+                        CONFIDENTIAL,
+                        otherDocsList
+                    ));
         }
     }
 
@@ -901,6 +912,7 @@ public class CafcassCaseDataService {
             "data.respondentCc8Documents",
             "data.respondentDc8Documents",
             "data.respondentEc8Documents",
+            "data.otherPartyC8Documents",
             "data.c8FormDocumentsUploaded",
             "data.bundleInformation",
             "data.otherDocumentsUploaded",

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataServiceTest.java
@@ -614,6 +614,7 @@ class CafcassCaseDataServiceTest {
             .respondentCc8Documents(List.of(element(responseDocuments)))
             .respondentDc8Documents(List.of(element(responseDocuments)))
             .respondentEc8Documents(List.of(element(responseDocuments)))
+            .otherPartyC8Documents(List.of(element(responseDocuments)))
             .specialArrangementsLetter(document)
             .additionalDocuments(document)
             .additionalDocumentsList(List.of(element(document)))


### PR DESCRIPTION
### JIRA link (if applicable) ###
2202, 2490


### Change description ###
 - Ensure newly generated Other Person C8s are visible on the Cafcass API


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
