### PR TITLE
FPVTL-2292: Stale data pulling onto respondent C8 when solicitor responding

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/handlers/CaseEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/handlers/CaseEventHandler.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.prl.models.Element;
 import uk.gov.hmcts.reform.prl.models.EventValidationErrors;
 import uk.gov.hmcts.reform.prl.models.c100respondentsolicitor.RespondentEventValidationErrors;
 import uk.gov.hmcts.reform.prl.models.complextypes.PartyDetails;
+import uk.gov.hmcts.reform.prl.models.complextypes.tab.summarytab.summary.refuge.RefugeCase;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.models.tasklist.RespondentTask;
 import uk.gov.hmcts.reform.prl.models.tasklist.Task;
@@ -25,6 +26,7 @@ import uk.gov.hmcts.reform.prl.services.TaskListService;
 import uk.gov.hmcts.reform.prl.services.c100respondentsolicitor.RespondentSolicitorTaskListRenderer;
 import uk.gov.hmcts.reform.prl.services.c100respondentsolicitor.RespondentTaskErrorService;
 import uk.gov.hmcts.reform.prl.services.tab.alltabs.AllTabServiceImpl;
+import uk.gov.hmcts.reform.prl.services.tab.summary.generator.refuge.RefugeCaseGenerator;
 
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,7 @@ public class CaseEventHandler {
     private final TaskErrorService taskErrorService;
     private final RespondentTaskErrorService respondentTaskErrorService;
     private final AllTabServiceImpl allTabService;
+    private final RefugeCaseGenerator refugeCaseGenerator;
 
     @EventListener
     public void handleCaseDataChange(final CaseDataChanged event) {
@@ -70,6 +73,7 @@ public class CaseEventHandler {
         final String respondentTaskListC = getRespondentTaskList(startAllTabsUpdateDataContent.caseData(), C100_RESPONDENT_EVENTS_C);
         final String respondentTaskListD = getRespondentTaskList(startAllTabsUpdateDataContent.caseData(), C100_RESPONDENT_EVENTS_D);
         final String respondentTaskListE = getRespondentTaskList(startAllTabsUpdateDataContent.caseData(), C100_RESPONDENT_EVENTS_E);
+        final RefugeCase refugeCase = refugeCaseGenerator.generate(startAllTabsUpdateDataContent.caseData()).getRefugeCase();
         Map<String, Object> combinedFieldsMap = Map.of(
                 TASK_LIST,
                 taskList,
@@ -86,7 +90,9 @@ public class CaseEventHandler {
                 C100_RESPONDENT_TASK_LIST_E,
                 respondentTaskListE,
                 ID,
-                caseId
+                caseId,
+                "refugeCase",
+                refugeCase
         );
         allTabService.submitAllTabsUpdate(startAllTabsUpdateDataContent.authorisation(),
                 caseId,

--- a/src/main/java/uk/gov/hmcts/reform/prl/handlers/CaseEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/handlers/CaseEventHandler.java
@@ -51,6 +51,7 @@ public class CaseEventHandler {
     public static final String C100_RESPONDENT_TASK_LIST_D = "respondentTaskListD";
     public static final String C100_RESPONDENT_TASK_LIST_E = "respondentTaskListE";
     public static final String C100_RESPONDENT_TASK_LIST = "respondentTaskList";
+    public static final String REFUGE_CASE = "refugeCase";
     public static final String TASK_LIST = "taskList";
     public static final String ID = "id";
 
@@ -91,7 +92,7 @@ public class CaseEventHandler {
                 respondentTaskListE,
                 ID,
                 caseId,
-                "refugeCase",
+                REFUGE_CASE,
                 refugeCase
         );
         allTabService.submitAllTabsUpdate(startAllTabsUpdateDataContent.authorisation(),

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/c100respondentsolicitor/C100RespondentSolicitorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/c100respondentsolicitor/C100RespondentSolicitorService.java
@@ -1049,7 +1049,7 @@ public class C100RespondentSolicitorService {
                 authorisation,
                 callbackRequest,
                 caseData,
-                representedRespondent,
+                element(representedRespondent.getId(), amended),
                 quarantineLegalDocList
             );
 

--- a/src/test/java/uk/gov/hmcts/reform/prl/handlers/CaseEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/handlers/CaseEventHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.prl.handlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -21,6 +22,8 @@ import uk.gov.hmcts.reform.prl.models.c100respondentsolicitor.RespondentEventVal
 import uk.gov.hmcts.reform.prl.models.complextypes.PartyDetails;
 import uk.gov.hmcts.reform.prl.models.complextypes.citizen.Response;
 import uk.gov.hmcts.reform.prl.models.complextypes.citizen.User;
+import uk.gov.hmcts.reform.prl.models.complextypes.tab.summarytab.CaseSummary;
+import uk.gov.hmcts.reform.prl.models.complextypes.tab.summarytab.summary.refuge.RefugeCase;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.models.tasklist.RespondentTask;
 import uk.gov.hmcts.reform.prl.models.tasklist.Task;
@@ -30,6 +33,7 @@ import uk.gov.hmcts.reform.prl.services.TaskListService;
 import uk.gov.hmcts.reform.prl.services.c100respondentsolicitor.RespondentSolicitorTaskListRenderer;
 import uk.gov.hmcts.reform.prl.services.c100respondentsolicitor.RespondentTaskErrorService;
 import uk.gov.hmcts.reform.prl.services.tab.alltabs.AllTabServiceImpl;
+import uk.gov.hmcts.reform.prl.services.tab.summary.generator.refuge.RefugeCaseGenerator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,6 +42,7 @@ import java.util.Map;
 
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,6 +65,9 @@ import static uk.gov.hmcts.reform.prl.utils.ElementUtils.element;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class CaseEventHandlerTest {
+
+    @Mock
+    private RefugeCaseGenerator refugeCaseGenerator;
 
     @Mock
     private TaskListService taskListService;
@@ -85,6 +93,15 @@ public class CaseEventHandlerTest {
     private  ObjectMapper objectMapper;
 
     public static final String authToken = "Bearer TestAuthToken";
+
+    @Before
+    public void init() {
+        when(refugeCaseGenerator.generate(any()))
+            .thenReturn(CaseSummary.builder()
+                            .refugeCase(RefugeCase.builder()
+                                            .isRefugeCase(YesOrNo.No)
+                                            .build()).build());
+    }
 
     @Test
     public void shouldUpdateTaskListForCasesInOpenStateC100() {
@@ -391,7 +408,7 @@ public class CaseEventHandlerTest {
         caseEventHandler.getRespondentTaskList(caseData, "A");
 
         verify(respondentSolicitorTaskListRenderer).render(Mockito.anyList(), Mockito.anyList(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyBoolean(), Mockito.any()
+                Mockito.anyString(), Mockito.anyBoolean(), any()
         );
 
     }
@@ -456,8 +473,9 @@ public class CaseEventHandlerTest {
 
         caseEventHandler.getRespondentTaskList(caseData, "A");
 
-        verify(respondentSolicitorTaskListRenderer).render(Mockito.any(), Mockito.any(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyBoolean(), Mockito.any()
+        verify(respondentSolicitorTaskListRenderer).render(
+            any(), any(), Mockito.anyString(),
+            Mockito.anyString(), Mockito.anyBoolean(), any()
         );
 
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
FPVTL-2292:


### Change description ###
 - Ensure refugeCase is up to date after C7 response
 - Ensure stale respondent info isn't ending up on C8 doc


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
