### PR TITLE
fpvtl-2651: ignore redacted documents in cafcass call

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/cafcass/CafCassControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/prl/controllers/cafcass/CafCassControllerFunctionalTest.java
@@ -65,6 +65,10 @@ import static uk.gov.hmcts.reform.prl.utils.TestConstants.TEST_SERVICE_AUTH_TOKE
 public class CafCassControllerFunctionalTest {
 
     private static final String USER_TOKEN = "Bearer testToken";
+    private static final String CAFCASS_USER_ROLE = "caseworker-privatelaw-cafcass";
+    private static final String REDACTED_DOCUMENTS_RESPONSE =
+        "classpath:response/cafcass-search-response-redacted-documents.json";
+    private static final String VALID_DOCUMENT_UUID = "11111111-1111-1111-1111-111111111111";
 
     private MockMvc mockMvc;
 
@@ -95,6 +99,48 @@ public class CafCassControllerFunctionalTest {
     @Before
     public void setUp() {
         this.mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    public void givenRedactedDocumentsWhenGetRequestToSearchCasesThenRedactedDocumentsAreExcluded() throws Exception {
+        String cafcassResponseStr = new String(Files.readAllBytes(ResourceUtils.getFile(REDACTED_DOCUMENTS_RESPONSE).toPath()));
+        ObjectMapper objectMapper = CcdObjectMapper.getObjectMapper();
+        SearchResult expectedSearchResult = objectMapper.readValue(cafcassResponseStr, SearchResult.class);
+
+        Mockito.when(authorisationService.authoriseService(any())).thenReturn(true);
+        Mockito.when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
+        Mockito.when(authorisationService.authoriseUser(any())).thenReturn(Optional.of(userInfo));
+        Mockito.when(userInfo.getRoles()).thenReturn(List.of(CAFCASS_USER_ROLE));
+        when(systemUserService.getSysUserToken()).thenReturn(USER_TOKEN);
+        Mockito.when(coreCaseDataApi.searchCases(anyString(), anyString(), anyString(), anyString())).thenReturn(expectedSearchResult);
+
+        MvcResult mvcResult = mockMvc.perform(get(SEARCH_CASE_ENDPOINT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORISATION_HEADER, TEST_AUTH_TOKEN)
+                        .header(SERVICE_AUTHORISATION_HEADER, TEST_SERVICE_AUTH_TOKEN)
+                        .queryParam(CAFCASS_START_DATE_PARAM, "2022-08-22T10:54:43.49")
+                        .queryParam(CAFCASS_END_DATE_PARAM, "2022-08-22T11:00:43.49")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        CafCassResponse actualCafcassResponse = objectMapper.readValue(
+            mvcResult.getResponse().getContentAsString(),
+            CafCassResponse.class
+        );
+
+        assertEquals(1, actualCafcassResponse.getTotal());
+        assertEquals(1, actualCafcassResponse.getCases().getFirst().getCaseData().getOtherDocuments().size());
+        assertEquals(
+            VALID_DOCUMENT_UUID,
+            actualCafcassResponse.getCases().getFirst().getCaseData().getOtherDocuments().getFirst()
+                .getValue().getDocumentOther().getDocumentId()
+        );
+        assertEquals(
+            "valid-document.pdf",
+            actualCafcassResponse.getCases().getFirst().getCaseData().getOtherDocuments().getFirst()
+                .getValue().getDocumentName()
+        );
     }
 
     @Ignore

--- a/src/functionalTest/resources/response/cafcass-search-response-redacted-documents.json
+++ b/src/functionalTest/resources/response/cafcass-search-response-redacted-documents.json
@@ -1,0 +1,32 @@
+{
+  "total": 1,
+  "cases": [
+    {
+      "id": 1661164783455399,
+      "jurisdiction": "PRIVATELAW",
+      "state": "DECISION_OUTCOME",
+      "caseTypeOfApplication": "C100",
+      "case_type_id": "PRLAPPS",
+      "created_date": "2022-08-22T10:39:43.49",
+      "last_modified": "2022-08-22T10:44:54.055",
+      "case_data": {
+        "dateSubmitted": "2022-08-22",
+        "caseTypeOfApplication": "C100",
+        "caseManagementLocation": {
+          "regionId": "2",
+          "baseLocationId": "123456"
+        },
+        "otherDocumentsUploaded": [
+          {
+            "document_url": "http://dm-store-demo.service.core-compute-demo.internal/documents/00000000-0000-0000-0000-000000000000",
+            "document_filename": "*Redacted*.pdf"
+          },
+          {
+            "document_url": "http://dm-store-demo.service.core-compute-demo.internal/documents/11111111-1111-1111-1111-111111111111",
+            "document_filename": "valid-document.pdf"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataService.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CANCELLED;
@@ -163,6 +164,7 @@ public class CafcassCaseDataService {
                     updateHearingResponse(authorisation, s2sToken, filteredCafcassData);
                     addSpecificDocumentsFromCaseFileViewBasedOnCategories(filteredCafcassData);
                     filteredCafcassData = removeUnnecessaryFieldsFromResponse(filteredCafcassData);
+                    removeRedactedDocumentsFromResponse(filteredCafcassData);
                     for (CafCassCaseDetail cafcassCase : filteredCafcassData.getCases()) {
                         log.info("Found case with id {} and courtName {} ",
                                  cafcassCase.getId(), cafcassCase.getCaseData().getCourtName()
@@ -208,6 +210,41 @@ public class CafcassCaseDataService {
         return filteredCafcassData;
     }
 
+    private void removeRedactedDocumentsFromResponse(CafCassResponse filteredCafcassData) {
+        filteredCafcassData.getCases().forEach(cafCassCaseDetail -> {
+            CafCassCaseData caseData = cafCassCaseDetail.getCaseData();
+            if (caseData != null && CollectionUtils.isNotEmpty(caseData.getOtherDocuments())) {
+                caseData.setOtherDocuments(caseData.getOtherDocuments().stream()
+                                           .filter(element -> isNotRedactedDocument(element, this::getOtherDocumentId))
+                                           .toList());
+            }
+            if (caseData != null && CollectionUtils.isNotEmpty(caseData.getOrderCollection())) {
+                cafCassCaseDetail.setCaseData(caseData.toBuilder()
+                                                  .orderCollection(caseData.getOrderCollection().stream()
+                                                                       .filter(element -> isNotRedactedDocument(
+                                                                           element,
+                                                                           this::getOrderDocumentId
+                                                                       ))
+                                                                       .toList())
+                                                  .build());
+            }
+        });
+    }
+
+    private <T> boolean isNotRedactedDocument(Element<T> documentElement, Function<T, String> documentIdResolver) {
+        if (documentElement == null || documentElement.getValue() == null) {
+            return true;
+        }
+        return !REDACTED_DOCUMENT_UUID.equals(documentIdResolver.apply(documentElement.getValue()));
+    }
+
+    private String getOtherDocumentId(OtherDocuments otherDocument) {
+        return otherDocument.getDocumentOther() != null ? otherDocument.getDocumentOther().getDocumentId() : null;
+    }
+
+    private String getOrderDocumentId(CaseOrder order) {
+        return order.getOrderDocument() != null ? order.getOrderDocument().getDocumentId() : null;
+    }
 
     private List<Element<CaseOrder>> removeServeOrderDetails(List<Element<CaseOrder>> orderCollection) {
         if (!CollectionUtils.isEmpty(orderCollection)) {
@@ -627,10 +664,15 @@ public class CafcassCaseDataService {
         try {
             if (null != caseDocument && caseDocument.getDocumentUrl() != null
                 && !caseDocument.getDocumentUrl().endsWith(REDACTED_DOCUMENT_UUID)) {
-                otherDocsList.add(Element.<OtherDocuments>builder().id(
-                    UUID.randomUUID()).value(OtherDocuments.builder().documentOther(
-                    buildFromCaseDocument(caseDocument)).documentName(caseDocument.getDocumentFileName()).documentTypeOther(
-                    DocTypeOtherDocumentsEnum.getValue(category)).build()).build());
+                Document documentOther = buildFromCaseDocument(caseDocument);
+                otherDocsList.add(Element.<OtherDocuments>builder()
+                                      .id(UUID.randomUUID())
+                                      .value(OtherDocuments.builder()
+                                                 .documentOther(documentOther)
+                                                 .documentName(caseDocument.getDocumentFileName())
+                                                 .documentTypeOther(DocTypeOtherDocumentsEnum.getValue(category))
+                                                 .build())
+                                      .build());
             }
         } catch (MalformedURLException e) {
             log.error("Error in populating otherDocsList for CAFCASS {}", e.getMessage());

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/cafcass/CafcassCaseDataServiceTest.java
@@ -47,6 +47,8 @@ import uk.gov.hmcts.reform.prl.models.dto.cafcass.CafCassCaseDetail;
 import uk.gov.hmcts.reform.prl.models.dto.cafcass.CafCassResponse;
 import uk.gov.hmcts.reform.prl.models.dto.cafcass.Element;
 import uk.gov.hmcts.reform.prl.models.dto.cafcass.OtherDocuments;
+import uk.gov.hmcts.reform.prl.models.dto.cafcass.manageorder.CaseOrder;
+import uk.gov.hmcts.reform.prl.models.dto.cafcass.manageorder.OrderDocument;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.HearingData;
 import uk.gov.hmcts.reform.prl.models.dto.notify.serviceofapplication.EmailNotificationDetails;
@@ -82,6 +84,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertNull;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.ORDER_COLLECTION;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.REDACTED_DOCUMENT_UUID;
 import static uk.gov.hmcts.reform.prl.utils.ElementUtils.element;
 
 
@@ -703,6 +706,88 @@ class CafcassCaseDataServiceTest {
 
         assertTrue(otherDocsList.isEmpty());
 
+    }
+
+    @Test
+    void testRedactedDocumentIdsRemovedFromResponseOtherDocuments() throws NoSuchMethodException,
+        InvocationTargetException, IllegalAccessException {
+        uk.gov.hmcts.reform.prl.models.dto.cafcass.Document redactedDocument =
+            uk.gov.hmcts.reform.prl.models.dto.cafcass.Document.builder()
+                .documentId(REDACTED_DOCUMENT_UUID)
+                .documentFileName("*Redacted*")
+                .build();
+        uk.gov.hmcts.reform.prl.models.dto.cafcass.Document document =
+            uk.gov.hmcts.reform.prl.models.dto.cafcass.Document.builder()
+                .documentId("11111111-1111-1111-1111-111111111111")
+                .documentFileName("test.pdf")
+                .build();
+
+        CafCassCaseData cafCassCaseData = CafCassCaseData.builder()
+            .otherDocuments(List.of(
+                Element.<OtherDocuments>builder()
+                    .id(UUID.randomUUID())
+                    .value(OtherDocuments.builder().documentName("*Redacted*").documentOther(redactedDocument).build())
+                    .build(),
+                Element.<OtherDocuments>builder()
+                    .id(UUID.randomUUID())
+                    .value(OtherDocuments.builder().documentName("test.pdf").documentOther(document).build())
+                    .build()
+            ))
+            .build();
+        CafCassResponse cafCassResponse = CafCassResponse.builder()
+            .cases(List.of(CafCassCaseDetail.builder().caseData(cafCassCaseData).build()))
+            .build();
+
+        Method privateMethod = CafcassCaseDataService.class.getDeclaredMethod(
+            "removeRedactedDocumentsFromResponse",
+            CafCassResponse.class
+        );
+        privateMethod.setAccessible(true);
+        privateMethod.invoke(cafcassCaseDataService, cafCassResponse);
+
+        List<Element<OtherDocuments>> otherDocuments = cafCassResponse.getCases().get(0).getCaseData().getOtherDocuments();
+        assertEquals(1, otherDocuments.size());
+        assertEquals("test.pdf", otherDocuments.get(0).getValue().getDocumentName());
+    }
+
+    @Test
+    void testRedactedDocumentIdsRemovedFromResponseOrderCollection() throws NoSuchMethodException,
+        InvocationTargetException, IllegalAccessException {
+        OrderDocument redactedDocument = OrderDocument.builder()
+            .documentId(REDACTED_DOCUMENT_UUID)
+            .documentFilename("*Redacted*")
+            .build();
+        OrderDocument document = OrderDocument.builder()
+            .documentId("11111111-1111-1111-1111-111111111111")
+            .documentFilename("order.pdf")
+            .build();
+
+        CafCassCaseData cafCassCaseData = CafCassCaseData.builder()
+            .orderCollection(List.of(
+                Element.<CaseOrder>builder()
+                    .id(UUID.randomUUID())
+                    .value(CaseOrder.builder().orderDocument(redactedDocument).build())
+                    .build(),
+                Element.<CaseOrder>builder()
+                    .id(UUID.randomUUID())
+                    .value(CaseOrder.builder().orderDocument(document).build())
+                    .build()
+            ))
+            .build();
+        CafCassResponse cafCassResponse = CafCassResponse.builder()
+            .cases(List.of(CafCassCaseDetail.builder().caseData(cafCassCaseData).build()))
+            .build();
+
+        Method privateMethod = CafcassCaseDataService.class.getDeclaredMethod(
+            "removeRedactedDocumentsFromResponse",
+            CafCassResponse.class
+        );
+        privateMethod.setAccessible(true);
+        privateMethod.invoke(cafcassCaseDataService, cafCassResponse);
+
+        List<Element<CaseOrder>> orderCollection = cafCassResponse.getCases().get(0).getCaseData().getOrderCollection();
+        assertEquals(1, orderCollection.size());
+        assertEquals("order.pdf", orderCollection.get(0).getValue().getOrderDocument().getDocumentFilename());
     }
 
     @Test


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


[2651](https://tools.hmcts.net/jira/browse/FPVTL-2651)



### Change description ###
Added logic to ignore redacted documents from cases when Cafcass makes a call to search a case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
