### PR TITLE
FPVTL-2963: Applicant DOB should not be added in manifest

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadService.java
@@ -146,6 +146,7 @@ public class BaisDocumentUploadService {
             .id(caseData.getId())
             .caseTypeOfApplication(caseData.getCaseTypeOfApplication())
             .applicant(applicant.toBuilder()
+                           .dateOfBirth(null)
                            .isAddressConfidential(ofNullable(applicant.getIsAddressConfidential()).orElse(YesOrNo.No))
                            .isPhoneNumberConfidential(ofNullable(applicant.getIsPhoneNumberConfidential())
                                                           .orElse(YesOrNo.No))

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadServiceTest.java
@@ -413,9 +413,7 @@ class BaisDocumentUploadServiceTest {
             Object actual = mapping[1];
             String source = (String) mapping[2];
 
-            String format = String.format("%s should be mapped from %s", fieldName, source);
-            assertEquals(expected, actual, format
-            );
+            assertEquals(expected, actual, String.format("%s should be mapped from %s", fieldName, source));
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.prl.services.acro;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTED;
 
-@Slf4j
 @ExtendWith(SpringExtension.class)
 class BaisDocumentUploadServiceTest {
 
@@ -416,7 +414,6 @@ class BaisDocumentUploadServiceTest {
             String source = (String) mapping[2];
 
             String format = String.format("%s should be mapped from %s", fieldName, source);
-            log.info(format);
             assertEquals(expected, actual, format
             );
         });

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/acro/BaisDocumentUploadServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.prl.services.acro;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +30,7 @@ import uk.gov.hmcts.reform.prl.models.dto.acro.CsvData;
 import uk.gov.hmcts.reform.prl.services.SystemUserService;
 
 import java.io.File;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTED;
 
+@Slf4j
 @ExtendWith(SpringExtension.class)
 class BaisDocumentUploadServiceTest {
 
@@ -338,11 +341,13 @@ class BaisDocumentUploadServiceTest {
         PartyDetails applicant = PartyDetails.builder()
             .firstName("John")
             .lastName("Doe")
+            .dateOfBirth(LocalDate.of(2010, 1, 1))
             .build();
 
         PartyDetails respondent = PartyDetails.builder()
             .firstName("Jane")
             .lastName("Smith")
+            .dateOfBirth(LocalDate.of(2010, 1, 1))
             .build();
 
         AcroCaseData caseData = AcroCaseData.builder()
@@ -383,11 +388,13 @@ class BaisDocumentUploadServiceTest {
             "Case Type", new Object[]{caseData.getCaseTypeOfApplication(),
                 capturedData.getCaseTypeOfApplication(), "caseData.getCaseTypeOfApplication()"},
             "Applicant", new Object[]{caseData.getApplicant().toBuilder()
+                .dateOfBirth(null)
                 .isAddressConfidential(YesOrNo.No)
                 .isPhoneNumberConfidential(YesOrNo.No)
                 .isEmailAddressConfidential(YesOrNo.No).build(),
                 capturedData.getApplicant(), "caseData.getApplicant()"},
             "Respondent", new Object[]{caseData.getRespondent().toBuilder()
+                .dateOfBirth(LocalDate.of(2010, 1, 1))
                 .isAddressConfidential(YesOrNo.No)
                 .isPhoneNumberConfidential(YesOrNo.No)
                 .isEmailAddressConfidential(YesOrNo.No).build(),
@@ -407,8 +414,11 @@ class BaisDocumentUploadServiceTest {
             Object expected = mapping[0];
             Object actual = mapping[1];
             String source = (String) mapping[2];
-            assertEquals(expected, actual,
-                String.format("%s should be mapped from %s", fieldName, source));
+
+            String format = String.format("%s should be mapped from %s", fieldName, source);
+            log.info(format);
+            assertEquals(expected, actual, format
+            );
         });
     }
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] the `enable_keep_helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

[FPVTL-2963](https://tools.hmcts.net/jira/browse/FPVTL-2963)

### Change description ###

ACRO - Applicant Date Of Birth should not appear in the CSV manifest file

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
