### PR TITLE
FPVTL-3120: Fix orders being replaced with a prior custom order

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
@@ -1060,10 +1060,9 @@ public class ManageOrdersController {
             }
         }
 
-        // Check if this is a custom order by looking at customOrderNameOption in the callback data.
-        // This field is only set during the custom order flow and is cleaned up at the end of submitted callback.
-        // We can't use manageOrdersOptions because it gets cleaned up in about-to-submit.
-        // We can't use customOrderDoc because it was sticky (persisted from previous orders) - that's the bug we fixed.
+        // Check if this is a custom order by looking at performingAction in the callback data (this reflects the
+        // 'contents' page 1 option)
+        // We can't use any custom orders fields as they are sticky (persisted from previous orders)
         boolean isCustomOrder = createCustomOrder.getDisplayedValue().equals(callbackData.get(WA_PERFORMING_ACTION));
         if (isCustomOrder) {
             // Copy customOrderDateEnds to fl404CustomFields for FL404/FL404A/FL406 custom orders

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersController.java
@@ -93,6 +93,7 @@ import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.NAME_OF_ORDER;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.ORDER_COLLECTION;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.ORDER_HEARING_DETAILS;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.PREVIEW_ORDER_DOC;
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.WA_PERFORMING_ACTION;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.WHAT_DO_WITH_ORDER;
 import static uk.gov.hmcts.reform.prl.enums.State.DECISION_OUTCOME;
 import static uk.gov.hmcts.reform.prl.enums.State.PREPARE_FOR_HEARING_CONDUCT_HEARING;
@@ -1063,7 +1064,7 @@ public class ManageOrdersController {
         // This field is only set during the custom order flow and is cleaned up at the end of submitted callback.
         // We can't use manageOrdersOptions because it gets cleaned up in about-to-submit.
         // We can't use customOrderDoc because it was sticky (persisted from previous orders) - that's the bug we fixed.
-        boolean isCustomOrder = callbackData.get(CUSTOM_ORDER_NAME_OPTION) != null;
+        boolean isCustomOrder = createCustomOrder.getDisplayedValue().equals(callbackData.get(WA_PERFORMING_ACTION));
         if (isCustomOrder) {
             // Copy customOrderDateEnds to fl404CustomFields for FL404/FL404A/FL406 custom orders
             copyCustomOrderDateEndsToFl404(callbackData, caseDataUpdated);

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/ManageOrdersControllerTest.java
@@ -4764,6 +4764,7 @@ public class ManageOrdersControllerTest {
             .documentFileName("preview.pdf")
             .build();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
         callbackDataMap.put("previewOrderDoc", previewOrderDoc);
         callbackDataMap.put("nameOfOrder", "Test Custom Order");
@@ -4955,6 +4956,7 @@ public class ManageOrdersControllerTest {
         // Callback data with all custom order fields
         Map<String, Object> callbackDataMap = new HashMap<>();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
         callbackDataMap.put("previewOrderDoc", previewOrderDoc);
         callbackDataMap.put("customOrderNameOption", "other");
@@ -5075,6 +5077,7 @@ public class ManageOrdersControllerTest {
         // Callback data with FL404-related order type (nonMolestation)
         Map<String, Object> callbackDataMap = new HashMap<>();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
         callbackDataMap.put("customOrderNameOption", "nonMolestation");
         callbackDataMap.put("customOrderDateEndsOptions", "specifiedDateAndTime");
@@ -5938,6 +5941,7 @@ public class ManageOrdersControllerTest {
         Map<String, Object> callbackDataMap = new HashMap<>();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderNameOption", "blankOrderOrDirections");
         // No amendOrderSelectCheckOptions in map
 
@@ -6013,6 +6017,7 @@ public class ManageOrdersControllerTest {
         Map<String, Object> callbackDataMap = new HashMap<>();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderNameOption", "blankOrderOrDirections");
         callbackDataMap.put("orderCollection", callbackOrderCollection);
 
@@ -6095,6 +6100,7 @@ public class ManageOrdersControllerTest {
             .build();
         Map<String, Object> callbackDataMap = new HashMap<>();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
         callbackDataMap.put("customOrderNameOption", "blankOrderOrDirections");
         callbackDataMap.put("orderCollection", callbackOrderCollection);
@@ -6184,6 +6190,7 @@ public class ManageOrdersControllerTest {
         Map<String, Object> callbackDataMap = new HashMap<>();
         callbackDataMap.put("manageOrdersOptions", "createCustomOrder");
         callbackDataMap.put("customOrderDoc", customOrderDoc);
+        callbackDataMap.put("performingAction", "Create a custom order");
         callbackDataMap.put("customOrderNameOption", "blankOrderOrDirections");
         callbackDataMap.put("orderCollection", callbackOrderCollection);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPVTL-3120](https://tools.hmcts.net/jira/browse/FPVTL-3120)


### Change description ###
 - Use performingAction (set from the contents page/choice on page 1 of manage orders and persists for WA reasons) to determine whether we are currently processing a custom order or not.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
