### PR TITLE
FPVTL-3385 External message attachments

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/services/SendgridService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/SendgridService.java
@@ -101,6 +101,12 @@ public class SendgridService {
         Mail mail = new Mail();
         addCustomArgsCaseReference(mail, sendgridEmailConfig.getCaseReference());
         long attachDocsStartTime = System.currentTimeMillis();
+        log.info(
+            "Preparing SendGrid template email templateName={} caseReference={} attachmentCount={}",
+            sendgridEmailTemplateNames,
+            sendgridEmailConfig.getCaseReference(),
+            CollectionUtils.size(sendgridEmailConfig.getListOfAttachments())
+        );
         if (CollectionUtils.isNotEmpty(sendgridEmailConfig.getListOfAttachments())) {
             attachFiles(authorization, mail, getCommonEmailProps(), sendgridEmailConfig.getListOfAttachments());
         }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyCommonService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyCommonService.java
@@ -79,13 +79,6 @@ public class SendAndReplyCommonService {
             );
         }
 
-        // ensure the message content is set in sendMessageObject for access in submitted cb
-        caseDataMap.put("sendMessageObject", caseData.getSendOrReplyMessage().getSendMessageObject()
-            .toBuilder()
-                .messageContent(caseData.getMessageContent())
-            .build()
-        );
-
         //WA - clear reply field in case of SEND
         sendAndReplyService.removeTemporaryFields(caseDataMap, "replyMessageObject");
     }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyService.java
@@ -903,11 +903,24 @@ public class SendAndReplyService {
             .replyHistory(null)
             .hearingsLink(isNotBlank(getValueCode(message.getFutureHearingsList())) ? hearingsUrl : null)
             .messageIdentifier(SEND.equals(caseData.getChooseSendOrReply()) ? String.valueOf(UUID.randomUUID()) : null)
-            .externalMessageAttachDocs(getAttachedDocsForExternalMessage(
+            .externalMessageAttachDocs(getExternalMessageAttachedDocs(caseData, message, authorization))
+            .build();
+    }
+
+    private List<Element<Document>> getExternalMessageAttachedDocs(CaseData caseData, Message message, String authorization) {
+        List<Element<Document>> externalMessageAttachDocs = new ArrayList<>();
+        if (SEND.equals(caseData.getChooseSendOrReply())) {
+            externalMessageAttachDocs.addAll(getSendAttachedDocs(caseData, message, authorization));
+        }
+
+        if (caseData.getSendOrReplyMessage() != null) {
+            externalMessageAttachDocs.addAll(getAttachedDocsForExternalMessage(
                 authorization,
                 caseData.getSendOrReplyMessage().getExternalMessageAttachDocsList()
-            ))
-            .build();
+            ));
+        }
+
+        return externalMessageAttachDocs;
     }
 
     private List<Element<Document>> getSendAttachedDocs(CaseData caseData, Message message, String authorization) {
@@ -1877,22 +1890,27 @@ public class SendAndReplyService {
     }
 
     private List<Document> getExternalMessageSelectedDocumentList(CaseData caseData, String authorization, Message message) {
-        List<Document> selectedDocList = new ArrayList<>();
+        Optional<Message> savedMessageWithAttachments = getSavedExternalMessageWithAttachments(caseData, message);
+        return savedMessageWithAttachments
+            .map(Message::getExternalMessageAttachDocs)
+            .orElseGet(() -> getExternalMessageAttachedDocs(caseData, message, authorization)).stream()
+            .map(Element::getValue)
+            .filter(Objects::nonNull)
+            .toList();
+    }
 
-        Document selectedDoc = getSelectedDocument(authorization, message.getSubmittedDocumentsList());
-        if (null != selectedDoc) {
-            selectedDocList.add(selectedDoc);
+    private Optional<Message> getSavedExternalMessageWithAttachments(CaseData caseData, Message message) {
+        if (caseData.getSendOrReplyMessage() == null) {
+            return Optional.empty();
         }
 
-        List<Element<Document>> externalMessageDocList = getAttachedDocsForExternalMessage(
-            authorization,
-            caseData.getSendOrReplyMessage().getExternalMessageAttachDocsList()
-        );
-        if (null != externalMessageDocList && !externalMessageDocList.isEmpty()) {
-            externalMessageDocList.forEach(element -> selectedDocList.add(element.getValue()));
-
-        }
-        return selectedDocList;
+        return nullSafeCollection(caseData.getSendOrReplyMessage().getMessages()).stream()
+            .map(Element::getValue)
+            .filter(savedMessage -> InternalExternalMessageEnum.EXTERNAL.equals(savedMessage.getInternalOrExternalMessage()))
+            .filter(savedMessage -> isNotEmpty(savedMessage.getExternalMessageAttachDocs()))
+            .filter(savedMessage -> Objects.equals(savedMessage.getMessageSubject(), message.getMessageSubject()))
+            .filter(savedMessage -> Objects.equals(savedMessage.getMessageContent(), message.getMessageContent()))
+            .max(Comparator.comparing(Message::getUpdatedTime, Comparator.nullsLast(Comparator.naturalOrder())));
     }
 
     private Document getMessageDocument(String authorization, CaseData caseData, Message message,

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyService.java
@@ -1628,6 +1628,12 @@ public class SendAndReplyService {
         }
         addJudgeIdamIdIfMessageSentToJudge(caseData, newMessage, caseDataMap);
         applyMessageHandlers(caseData, caseDataMap, newMessage);
+        caseDataMap.put("sendMessageObject", caseData.getSendOrReplyMessage().getSendMessageObject()
+            .toBuilder()
+            .messageContent(caseData.getMessageContent())
+            .messageIdentifier(newMessage.getMessageIdentifier())
+            .build()
+        );
 
         messages.add(element(newMessage));
         messages.sort(Comparator.comparing(m -> m.getValue().getUpdatedTime(), Comparator.reverseOrder()));
@@ -1738,7 +1744,7 @@ public class SendAndReplyService {
                 );
                 if (party.isPresent()) {
 
-                    handleExternalMessageNotifications(caseData, auth, party);
+                    handleExternalMessageNotifications(caseData, auth, party, message);
                 }
             }
             );
@@ -1753,18 +1759,19 @@ public class SendAndReplyService {
             if (StringUtils.isNotEmpty(message.getOtherPartiesEmailAddress())) {
                 emails.addAll(List.of(StringUtils.split(message.getOtherPartiesEmailAddress(), ",")));
             }
-            sendEmailNotificationToCafcassAndOtherParties(caseData, emails, auth);
+            sendEmailNotificationToCafcassAndOtherParties(caseData, message, emails, auth);
 
         }
 
 
     }
 
-    private void handleExternalMessageNotifications(CaseData caseData, String auth, Optional<Element<PartyDetails>> party) {
+    private void handleExternalMessageNotifications(CaseData caseData, String auth, Optional<Element<PartyDetails>> party,
+                                                    Message message) {
         PartyDetails partyDetails = party.get().getValue();
         if (externalMessageToBeSentInEmail(partyDetails)) {
             try {
-                sendEmailNotification(caseData, partyDetails, auth);
+                sendEmailNotification(caseData, partyDetails, message, auth);
             } catch (Exception e) {
                 log.error("Error while sending email notification Case id {} ", caseData.getId(), e);
             }
@@ -1772,7 +1779,7 @@ public class SendAndReplyService {
 
             try {
                 sendPostNotificationToExternalParties(caseData, partyDetails,
-                                                      caseData.getSendOrReplyMessage().getSendMessageObject(), auth
+                                                      message, auth
                 );
 
                 log.info("Message sent as post to external parties");
@@ -1843,12 +1850,11 @@ public class SendAndReplyService {
     }
 
 
-    private void sendEmailNotification(CaseData caseData, PartyDetails partyDetails, String authorization) {
+    private void sendEmailNotification(CaseData caseData, PartyDetails partyDetails, Message message, String authorization) {
         String emailAddress = isSolicitorRepresentative(partyDetails) ? partyDetails.getSolicitorEmail() : partyDetails.getEmail();
 
-        Message message = caseData.getSendOrReplyMessage().getSendMessageObject();
         List<Document>  allSelectedDocuments = getExternalMessageSelectedDocumentList(caseData, authorization, message);
-        Map<String, Object> dynamicDataForEmail = getDynamicDataForEmail(caseData, partyDetails, allSelectedDocuments);
+        Map<String, Object> dynamicDataForEmail = getDynamicDataForEmail(caseData, partyDetails, message, allSelectedDocuments);
 
         sendgridService.sendEmailUsingTemplateWithAttachments(
             SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY,
@@ -1861,8 +1867,8 @@ public class SendAndReplyService {
                 .build());
     }
 
-    private void sendEmailNotificationToCafcassAndOtherParties(CaseData caseData, List<String> emails, String authorization) {
-        Message message = caseData.getSendOrReplyMessage().getSendMessageObject();
+    private void sendEmailNotificationToCafcassAndOtherParties(CaseData caseData, Message message, List<String> emails,
+                                                               String authorization) {
         List<Document>  allSelectedDocuments = getExternalMessageSelectedDocumentList(caseData, authorization, message);
         Map<String, Object> dynamicData = EmailUtils.getCommonSendgridDynamicTemplateData(caseData);
         setMessageDataForEmail(caseData,message,allSelectedDocuments,dynamicData);
@@ -1903,21 +1909,20 @@ public class SendAndReplyService {
         if (caseData.getSendOrReplyMessage() == null) {
             return Optional.empty();
         }
+        if (StringUtils.isBlank(message.getMessageIdentifier())) {
+            log.warn(
+                "Cannot resolve saved external message attachments because messageIdentifier is missing for caseReference={}",
+                caseData.getId()
+            );
+            return Optional.empty();
+        }
 
         return nullSafeCollection(caseData.getSendOrReplyMessage().getMessages()).stream()
             .map(Element::getValue)
             .filter(savedMessage -> InternalExternalMessageEnum.EXTERNAL.equals(savedMessage.getInternalOrExternalMessage()))
             .filter(savedMessage -> isNotEmpty(savedMessage.getExternalMessageAttachDocs()))
-            .filter(savedMessage -> isMatchingExternalMessage(savedMessage, message))
+            .filter(savedMessage -> Objects.equals(savedMessage.getMessageIdentifier(), message.getMessageIdentifier()))
             .max(Comparator.comparing(Message::getUpdatedTime, Comparator.nullsFirst(Comparator.naturalOrder())));
-    }
-
-    private boolean isMatchingExternalMessage(Message savedMessage, Message message) {
-        if (StringUtils.isNotBlank(message.getMessageIdentifier())) {
-            return Objects.equals(savedMessage.getMessageIdentifier(), message.getMessageIdentifier());
-        }
-        return Objects.equals(savedMessage.getMessageSubject(), message.getMessageSubject())
-            && Objects.equals(savedMessage.getMessageContent(), message.getMessageContent());
     }
 
     private Document getMessageDocument(String authorization, CaseData caseData, Message message,
@@ -2075,8 +2080,8 @@ public class SendAndReplyService {
         return applicantsRespondentInCase;
     }
 
-    private Map<String, Object> getDynamicDataForEmail(CaseData caseData, PartyDetails partyDetails, List<Document>  allSelectedDocuments) {
-        Message message = caseData.getSendOrReplyMessage().getSendMessageObject();
+    private Map<String, Object> getDynamicDataForEmail(CaseData caseData, PartyDetails partyDetails, Message message,
+                                                       List<Document> allSelectedDocuments) {
         // get selected Document size
         Map<String, Object> dynamicData = EmailUtils.getCommonSendgridDynamicTemplateData(caseData);
         String receiverFullName = getReceiverFullName(partyDetails);

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyService.java
@@ -1908,9 +1908,16 @@ public class SendAndReplyService {
             .map(Element::getValue)
             .filter(savedMessage -> InternalExternalMessageEnum.EXTERNAL.equals(savedMessage.getInternalOrExternalMessage()))
             .filter(savedMessage -> isNotEmpty(savedMessage.getExternalMessageAttachDocs()))
-            .filter(savedMessage -> Objects.equals(savedMessage.getMessageSubject(), message.getMessageSubject()))
-            .filter(savedMessage -> Objects.equals(savedMessage.getMessageContent(), message.getMessageContent()))
-            .max(Comparator.comparing(Message::getUpdatedTime, Comparator.nullsLast(Comparator.naturalOrder())));
+            .filter(savedMessage -> isMatchingExternalMessage(savedMessage, message))
+            .max(Comparator.comparing(Message::getUpdatedTime, Comparator.nullsFirst(Comparator.naturalOrder())));
+    }
+
+    private boolean isMatchingExternalMessage(Message savedMessage, Message message) {
+        if (StringUtils.isNotBlank(message.getMessageIdentifier())) {
+            return Objects.equals(savedMessage.getMessageIdentifier(), message.getMessageIdentifier());
+        }
+        return Objects.equals(savedMessage.getMessageSubject(), message.getMessageSubject())
+            && Objects.equals(savedMessage.getMessageContent(), message.getMessageContent());
     }
 
     private Document getMessageDocument(String authorization, CaseData caseData, Message message,

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
@@ -1000,6 +1000,83 @@ public class SendAndReplyServiceTest {
     }
 
     @Test
+    public void testBuildSendMessageAttachesSelectedSubmittedDocumentToExternalMessage() {
+        UUID selectedDocumentId = UUID.randomUUID();
+        DynamicList selectedDocumentList = dynamicDocumentList(selectedDocumentId, "Selected Document.pdf");
+
+        CaseData data = CaseData.builder()
+            .messageContent("some message while sending")
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication(PrlAppsConstants.C100_CASE_TYPE)
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(
+                        Message.builder()
+                            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+                            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+                            .submittedDocumentsList(selectedDocumentList)
+                            .build()
+                    ).build())
+            .build();
+
+        when(caseDocumentClient.getMetadataForDocument(eq(auth), eq(serviceAuthToken), eq(selectedDocumentId)))
+            .thenReturn(testDocument());
+
+        Message message = sendAndReplyService.buildSendReplyMessage(
+            data,
+            data.getSendOrReplyMessage().getSendMessageObject(),
+            auth
+        );
+
+        List<Element<uk.gov.hmcts.reform.prl.models.documents.Document>> attachedDocs = message.getExternalMessageAttachDocs();
+        assertEquals(1, attachedDocs.size());
+        assertEquals("Selected Document.pdf", attachedDocs.getFirst().getValue().getDocumentFileName());
+    }
+
+    @Test
+    public void testBuildSendMessageCombinesSelectedSubmittedDocumentAndExternalAttachments() {
+        UUID selectedDocumentId = UUID.randomUUID();
+        UUID externalAttachmentId = UUID.randomUUID();
+        DynamicList selectedDocumentList = dynamicDocumentList(selectedDocumentId, "Selected Document.pdf");
+        DynamicList externalAttachmentList = dynamicDocumentList(externalAttachmentId, "Extra Attachment.pdf");
+
+        CaseData data = CaseData.builder()
+            .messageContent("some message while sending")
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication(PrlAppsConstants.C100_CASE_TYPE)
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(
+                        Message.builder()
+                            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+                            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+                            .submittedDocumentsList(selectedDocumentList)
+                            .build()
+                    )
+                    .externalMessageAttachDocsList(List.of(element(SendAndReplyDynamicDoc.builder()
+                        .submittedDocsRefList(externalAttachmentList)
+                        .build())))
+                    .build())
+            .build();
+
+        when(caseDocumentClient.getMetadataForDocument(eq(auth), eq(serviceAuthToken), eq(selectedDocumentId)))
+            .thenReturn(testDocument());
+        when(caseDocumentClient.getMetadataForDocument(eq(auth), eq(serviceAuthToken), eq(externalAttachmentId)))
+            .thenReturn(testDocument());
+
+        Message message = sendAndReplyService.buildSendReplyMessage(
+            data,
+            data.getSendOrReplyMessage().getSendMessageObject(),
+            auth
+        );
+
+        List<Element<uk.gov.hmcts.reform.prl.models.documents.Document>> attachedDocs = message.getExternalMessageAttachDocs();
+        assertEquals(2, attachedDocs.size());
+        assertEquals("Selected Document.pdf", attachedDocs.getFirst().getValue().getDocumentFileName());
+        assertEquals("Extra Attachment.pdf", attachedDocs.get(1).getValue().getDocumentFileName());
+    }
+
+    @Test
     public void testBuildSendMessageWithMessageForNoRolesinUserDetails() {
         CaseData caseData = CaseData.builder()
             .messageContent("some message while sending")
@@ -2554,6 +2631,166 @@ public class SendAndReplyServiceTest {
     }
 
     @Test
+    public void testSendEmailNotificationToExternalPartiesC100CaseIncludesSelectedApplicationDocument() {
+        PartyDetails applicant = PartyDetails.builder()
+            .partyId(UUID.randomUUID())
+            .representativeFirstName("Abc")
+            .representativeLastName("Xyz")
+            .firstName("Applicant firstname")
+            .lastName("Applicant lastName")
+            .gender(Gender.male)
+            .email("abc@xyz.com")
+            .solicitorEmail("testSolicitor@xyz.com")
+            .phoneNumber("1234567890")
+            .contactPreferences(ContactPreferences.email)
+            .canYouProvideEmailAddress(YesOrNo.Yes)
+            .isEmailAddressConfidential(YesOrNo.Yes)
+            .isPhoneNumberConfidential(YesOrNo.Yes)
+            .solicitorOrg(Organisation.builder().organisationID("ABC").organisationName("XYZ").build())
+            .solicitorAddress(Address.builder().addressLine1("ABC").postCode("AB1 2MN").build())
+            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .build();
+
+        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder().id(applicant.getPartyId()).value(
+            applicant).build();
+
+        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
+            .value(List.of(DynamicMultiselectListElement.builder()
+                               .code(wrappedApplicant.getId().toString())
+                               .label(applicant.getFirstName() + " " + applicant.getLastName())
+                               .build()))
+            .build();
+        DynamicList applicationsList = DynamicList.builder()
+            .value(DynamicListElement.builder()
+                       .code(awpOtherCode)
+                       .label("test-document")
+                       .build())
+            .build();
+
+        CaseData caseDataC100Message = CaseData.builder().id(12345L)
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication("C100")
+            .replyMessageDynamicList(DynamicList.builder().build())
+            .applicants(List.of(wrappedApplicant))
+            .respondents(emptyList())
+            .messageContent("some msg content")
+            .additionalApplicationsBundle(List.of(element(AdditionalApplicationsBundle.builder()
+                .otherApplicationsBundle(OtherApplicationsBundle.builder()
+                                             .applicationStatus(AWP_STATUS_SUBMITTED)
+                                             .applicationType(OtherApplicationType.FC600_COMMITTAL_APPLICATION)
+                                             .uploadedDateTime(dateSent)
+                                             .finalDocument(List.of(element(internalMessageDoc)))
+                                             .build())
+                .build())))
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(Message.builder()
+                                           .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+                                           .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
+                                           .messageAbout(MessageAboutEnum.APPLICATION)
+                                           .applicationsList(applicationsList)
+                                           .messageContent("some msg content")
+                                           .messageSubject("message subject")
+                                           .build()
+                    )
+                    .respondToMessage(YesOrNo.No)
+                    .messages(messages)
+                    .build())
+            .build();
+
+        sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
+
+        ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
+        verify(sendgridService).sendEmailUsingTemplateWithAttachments(
+            eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
+            eq("authorisation"),
+            sendgridEmailConfigCaptor.capture()
+        );
+        SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
+        assertEquals(1, sendgridEmailConfig.getListOfAttachments().size());
+        assertEquals(internalMessageDoc.getDocumentFileName(),
+                     sendgridEmailConfig.getListOfAttachments().getFirst().getDocumentFileName());
+        assertEquals(1, sendgridEmailConfig.getDynamicTemplateData().get("documentSize"));
+    }
+
+    @Test
+    public void testSendEmailNotificationUsesSavedExternalMessageAttachmentsWhenTemporaryAttachListRemoved() {
+        PartyDetails applicant = PartyDetails.builder()
+            .partyId(UUID.randomUUID())
+            .representativeFirstName("Abc")
+            .representativeLastName("Xyz")
+            .firstName("Applicant firstname")
+            .lastName("Applicant lastName")
+            .gender(Gender.male)
+            .email("abc@xyz.com")
+            .solicitorEmail("testSolicitor@xyz.com")
+            .phoneNumber("1234567890")
+            .contactPreferences(ContactPreferences.email)
+            .canYouProvideEmailAddress(YesOrNo.Yes)
+            .isEmailAddressConfidential(YesOrNo.Yes)
+            .isPhoneNumberConfidential(YesOrNo.Yes)
+            .solicitorOrg(Organisation.builder().organisationID("ABC").organisationName("XYZ").build())
+            .solicitorAddress(Address.builder().addressLine1("ABC").postCode("AB1 2MN").build())
+            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .build();
+
+        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder().id(applicant.getPartyId()).value(
+            applicant).build();
+        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
+            .value(List.of(DynamicMultiselectListElement.builder()
+                               .code(wrappedApplicant.getId().toString())
+                               .label(applicant.getFirstName() + " " + applicant.getLastName())
+                               .build()))
+            .build();
+        uk.gov.hmcts.reform.prl.models.documents.Document manuallyAddedDoc = internalMessageDoc.toBuilder()
+            .documentFileName("manually-added-doc.pdf")
+            .build();
+
+        Message sendMessageObject = Message.builder()
+            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+            .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
+            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+            .messageContent("some msg content")
+            .messageSubject("message subject")
+            .build();
+        Message savedMessage = sendMessageObject.toBuilder()
+            .updatedTime(dateTime)
+            .externalMessageAttachDocs(List.of(element(internalMessageDoc), element(manuallyAddedDoc)))
+            .build();
+
+        CaseData caseDataC100Message = CaseData.builder().id(12345L)
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication("C100")
+            .replyMessageDynamicList(DynamicList.builder().build())
+            .applicants(List.of(wrappedApplicant))
+            .respondents(emptyList())
+            .messageContent("some msg content")
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(sendMessageObject)
+                    .respondToMessage(YesOrNo.No)
+                    .messages(List.of(element(savedMessage)))
+                    .build())
+            .build();
+
+        sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
+
+        ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
+        verify(sendgridService).sendEmailUsingTemplateWithAttachments(
+            eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
+            eq("authorisation"),
+            sendgridEmailConfigCaptor.capture()
+        );
+        SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
+        assertEquals(2, sendgridEmailConfig.getListOfAttachments().size());
+        assertEquals(internalMessageDoc.getDocumentFileName(),
+                     sendgridEmailConfig.getListOfAttachments().getFirst().getDocumentFileName());
+        assertEquals("manually-added-doc.pdf",
+                     sendgridEmailConfig.getListOfAttachments().get(1).getDocumentFileName());
+        assertEquals(2, sendgridEmailConfig.getDynamicTemplateData().get("documentSize"));
+    }
+
+    @Test
     public void testSendEmailNotificationToCafcassAndOthersC100Case() {
 
         PartyDetails applicant = PartyDetails.builder()
@@ -3860,5 +4097,14 @@ public class SendAndReplyServiceTest {
         document.originalDocumentName = RANDOM_ALPHA_NUMERIC;
 
         return document;
+    }
+
+    private DynamicList dynamicDocumentList(UUID documentId, String documentName) {
+        return DynamicList.builder()
+            .value(DynamicListElement.builder()
+                       .code(documentId)
+                       .label(documentName)
+                       .build())
+            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
@@ -2955,6 +2955,72 @@ public class SendAndReplyServiceTest {
     }
 
     @Test
+    public void testSendEmailNotificationDoesNotUseSavedExternalMessageAttachmentsWhenSubjectOrContentDoesNotMatch() {
+        PartyDetails applicant = getApplicant().toBuilder()
+            .firstName("Applicant firstname")
+            .lastName("Applicant lastName")
+            .solicitorEmail("testSolicitor@xyz.com")
+            .contactPreferences(ContactPreferences.email)
+            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .build();
+        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder()
+            .id(applicant.getPartyId())
+            .value(applicant)
+            .build();
+        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
+            .value(List.of(DynamicMultiselectListElement.builder()
+                               .code(wrappedApplicant.getId().toString())
+                               .label(applicant.getFirstName() + " " + applicant.getLastName())
+                               .build()))
+            .build();
+
+        Message sendMessageObject = Message.builder()
+            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+            .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
+            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+            .messageContent("matching content")
+            .messageSubject("matching subject")
+            .build();
+        Message subjectMismatchSavedMessage = sendMessageObject.toBuilder()
+            .messageSubject("different subject")
+            .updatedTime(dateTime)
+            .externalMessageAttachDocs(List.of(element(internalMessageDoc)))
+            .build();
+        Message contentMismatchSavedMessage = sendMessageObject.toBuilder()
+            .messageContent("different content")
+            .updatedTime(dateTime.plusMinutes(1))
+            .externalMessageAttachDocs(List.of(element(internalMessageDoc)))
+            .build();
+
+        CaseData caseDataC100Message = CaseData.builder().id(12345L)
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication("C100")
+            .replyMessageDynamicList(DynamicList.builder().build())
+            .applicants(List.of(wrappedApplicant))
+            .respondents(emptyList())
+            .messageContent("matching content")
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(sendMessageObject)
+                    .respondToMessage(YesOrNo.No)
+                    .messages(List.of(element(subjectMismatchSavedMessage), element(contentMismatchSavedMessage)))
+                    .build())
+            .build();
+
+        sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
+
+        ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
+        verify(sendgridService).sendEmailUsingTemplateWithAttachments(
+            eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
+            eq("authorisation"),
+            sendgridEmailConfigCaptor.capture()
+        );
+        SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
+        assertTrue(sendgridEmailConfig.getListOfAttachments().isEmpty());
+        assertEquals(0, sendgridEmailConfig.getDynamicTemplateData().get("documentSize"));
+    }
+
+    @Test
     public void testSendEmailNotificationToCafcassAndOthersC100Case() {
 
         PartyDetails applicant = PartyDetails.builder()

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.reform.prl.clients.RoleAssignmentApi;
 import uk.gov.hmcts.reform.prl.clients.ccd.records.StartAllTabsUpdateDataContent;
 import uk.gov.hmcts.reform.prl.config.launchdarkly.LaunchDarklyClient;
 import uk.gov.hmcts.reform.prl.constants.PrlAppsConstants;
+import uk.gov.hmcts.reform.prl.controllers.testingsupport.TestLogAppender;
 import uk.gov.hmcts.reform.prl.enums.ContactPreferences;
 import uk.gov.hmcts.reform.prl.enums.Gender;
 import uk.gov.hmcts.reform.prl.enums.LanguagePreference;
@@ -1673,6 +1674,9 @@ public class SendAndReplyServiceTest {
 
         assertEquals(2,updatedMessageList.size());
         assertEquals(TEST_UUID, caseDataMap.get(TASK_ASSIGNEE_IDAM_ID));
+        Message submittedSendMessageObject = (Message) caseDataMap.get("sendMessageObject");
+        assertEquals(updatedMessageList.getFirst().getValue().getMessageIdentifier(),
+                     submittedSendMessageObject.getMessageIdentifier());
     }
 
     @Test
@@ -2752,6 +2756,7 @@ public class SendAndReplyServiceTest {
             .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
             .messageContent("some msg content")
             .messageSubject("message subject")
+            .messageIdentifier("target-message-id")
             .build();
         Message savedMessage = sendMessageObject.toBuilder()
             .updatedTime(dateTime)
@@ -2874,6 +2879,80 @@ public class SendAndReplyServiceTest {
     }
 
     @Test
+    public void testSendEmailNotificationDoesNotUseSavedExternalMessageAttachmentsWhenNoIdentifierCanBeResolved() {
+        PartyDetails applicant = getApplicant().toBuilder()
+            .firstName("Applicant firstname")
+            .lastName("Applicant lastName")
+            .solicitorEmail("testSolicitor@xyz.com")
+            .contactPreferences(ContactPreferences.email)
+            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .build();
+        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder()
+            .id(applicant.getPartyId())
+            .value(applicant)
+            .build();
+        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
+            .value(List.of(DynamicMultiselectListElement.builder()
+                               .code(wrappedApplicant.getId().toString())
+                               .label(applicant.getFirstName() + " " + applicant.getLastName())
+                               .build()))
+            .build();
+
+        Message sendMessageObject = Message.builder()
+            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+            .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
+            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+            .messageContent("some msg content")
+            .messageSubject("message subject")
+            .build();
+        Message savedMessage = sendMessageObject.toBuilder()
+            .updatedTime(dateTime)
+            .externalMessageAttachDocs(List.of(element(internalMessageDoc)))
+            .build();
+
+        CaseData caseDataC100Message = CaseData.builder().id(12345L)
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication("C100")
+            .replyMessageDynamicList(DynamicList.builder().build())
+            .applicants(List.of(wrappedApplicant))
+            .respondents(emptyList())
+            .messageContent("some msg content")
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(sendMessageObject)
+                    .respondToMessage(YesOrNo.No)
+                    .messages(List.of(element(savedMessage)))
+                    .build())
+            .build();
+
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(
+            SendAndReplyService.class);
+        TestLogAppender appender = new TestLogAppender();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
+
+            ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
+            verify(sendgridService).sendEmailUsingTemplateWithAttachments(
+                eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
+                eq("authorisation"),
+                sendgridEmailConfigCaptor.capture()
+            );
+            SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
+            assertTrue(sendgridEmailConfig.getListOfAttachments().isEmpty());
+            assertEquals(0, sendgridEmailConfig.getDynamicTemplateData().get("documentSize"));
+            assertTrue(appender.getEvents().stream().anyMatch(
+                e -> e.getFormattedMessage().contains(
+                    "Cannot resolve saved external message attachments because messageIdentifier is missing for caseReference=12345")
+            ));
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
     public void testSendEmailNotificationPrefersDatedSavedExternalMessageAttachmentsOverNullUpdatedTime() {
         PartyDetails applicant = PartyDetails.builder()
             .partyId(UUID.randomUUID())
@@ -2915,6 +2994,7 @@ public class SendAndReplyServiceTest {
             .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
             .messageContent("same msg content")
             .messageSubject("same message subject")
+            .messageIdentifier("target-message-id")
             .build();
         Message nullUpdatedTimeSavedMessage = sendMessageObject.toBuilder()
             .updatedTime(null)
@@ -2952,72 +3032,6 @@ public class SendAndReplyServiceTest {
         assertEquals(1, sendgridEmailConfig.getListOfAttachments().size());
         assertEquals("dated-doc.pdf",
                      sendgridEmailConfig.getListOfAttachments().getFirst().getDocumentFileName());
-    }
-
-    @Test
-    public void testSendEmailNotificationDoesNotUseSavedExternalMessageAttachmentsWhenSubjectOrContentDoesNotMatch() {
-        PartyDetails applicant = getApplicant().toBuilder()
-            .firstName("Applicant firstname")
-            .lastName("Applicant lastName")
-            .solicitorEmail("testSolicitor@xyz.com")
-            .contactPreferences(ContactPreferences.email)
-            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
-            .build();
-        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder()
-            .id(applicant.getPartyId())
-            .value(applicant)
-            .build();
-        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
-            .value(List.of(DynamicMultiselectListElement.builder()
-                               .code(wrappedApplicant.getId().toString())
-                               .label(applicant.getFirstName() + " " + applicant.getLastName())
-                               .build()))
-            .build();
-
-        Message sendMessageObject = Message.builder()
-            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
-            .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
-            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
-            .messageContent("matching content")
-            .messageSubject("matching subject")
-            .build();
-        Message subjectMismatchSavedMessage = sendMessageObject.toBuilder()
-            .messageSubject("different subject")
-            .updatedTime(dateTime)
-            .externalMessageAttachDocs(List.of(element(internalMessageDoc)))
-            .build();
-        Message contentMismatchSavedMessage = sendMessageObject.toBuilder()
-            .messageContent("different content")
-            .updatedTime(dateTime.plusMinutes(1))
-            .externalMessageAttachDocs(List.of(element(internalMessageDoc)))
-            .build();
-
-        CaseData caseDataC100Message = CaseData.builder().id(12345L)
-            .chooseSendOrReply(SEND)
-            .caseTypeOfApplication("C100")
-            .replyMessageDynamicList(DynamicList.builder().build())
-            .applicants(List.of(wrappedApplicant))
-            .respondents(emptyList())
-            .messageContent("matching content")
-            .sendOrReplyMessage(
-                SendOrReplyMessage.builder()
-                    .sendMessageObject(sendMessageObject)
-                    .respondToMessage(YesOrNo.No)
-                    .messages(List.of(element(subjectMismatchSavedMessage), element(contentMismatchSavedMessage)))
-                    .build())
-            .build();
-
-        sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
-
-        ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
-        verify(sendgridService).sendEmailUsingTemplateWithAttachments(
-            eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
-            eq("authorisation"),
-            sendgridEmailConfigCaptor.capture()
-        );
-        SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
-        assertTrue(sendgridEmailConfig.getListOfAttachments().isEmpty());
-        assertEquals(0, sendgridEmailConfig.getDynamicTemplateData().get("documentSize"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
@@ -2791,6 +2791,89 @@ public class SendAndReplyServiceTest {
     }
 
     @Test
+    public void testSendEmailNotificationMatchesSavedExternalMessageAttachmentsByIdentifier() {
+        PartyDetails applicant = PartyDetails.builder()
+            .partyId(UUID.randomUUID())
+            .representativeFirstName("Abc")
+            .representativeLastName("Xyz")
+            .firstName("Applicant firstname")
+            .lastName("Applicant lastName")
+            .gender(Gender.male)
+            .email("abc@xyz.com")
+            .solicitorEmail("testSolicitor@xyz.com")
+            .phoneNumber("1234567890")
+            .contactPreferences(ContactPreferences.email)
+            .canYouProvideEmailAddress(YesOrNo.Yes)
+            .isEmailAddressConfidential(YesOrNo.Yes)
+            .isPhoneNumberConfidential(YesOrNo.Yes)
+            .solicitorOrg(Organisation.builder().organisationID("ABC").organisationName("XYZ").build())
+            .solicitorAddress(Address.builder().addressLine1("ABC").postCode("AB1 2MN").build())
+            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .build();
+
+        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder().id(applicant.getPartyId()).value(
+            applicant).build();
+        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
+            .value(List.of(DynamicMultiselectListElement.builder()
+                               .code(wrappedApplicant.getId().toString())
+                               .label(applicant.getFirstName() + " " + applicant.getLastName())
+                               .build()))
+            .build();
+        uk.gov.hmcts.reform.prl.models.documents.Document matchingDoc = internalMessageDoc.toBuilder()
+            .documentFileName("matching-doc.pdf")
+            .build();
+        uk.gov.hmcts.reform.prl.models.documents.Document newerNonMatchingDoc = internalMessageDoc.toBuilder()
+            .documentFileName("newer-non-matching-doc.pdf")
+            .build();
+
+        Message sendMessageObject = Message.builder()
+            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+            .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
+            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+            .messageContent("same msg content")
+            .messageSubject("same message subject")
+            .messageIdentifier("target-message-id")
+            .build();
+        Message matchingSavedMessage = sendMessageObject.toBuilder()
+            .updatedTime(dateTime)
+            .externalMessageAttachDocs(List.of(element(matchingDoc)))
+            .build();
+        Message newerNonMatchingSavedMessage = sendMessageObject.toBuilder()
+            .messageIdentifier("other-message-id")
+            .updatedTime(dateTime.plusMinutes(1))
+            .externalMessageAttachDocs(List.of(element(newerNonMatchingDoc)))
+            .build();
+
+        CaseData caseDataC100Message = CaseData.builder().id(12345L)
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication("C100")
+            .replyMessageDynamicList(DynamicList.builder().build())
+            .applicants(List.of(wrappedApplicant))
+            .respondents(emptyList())
+            .messageContent("same msg content")
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(sendMessageObject)
+                    .respondToMessage(YesOrNo.No)
+                    .messages(List.of(element(newerNonMatchingSavedMessage), element(matchingSavedMessage)))
+                    .build())
+            .build();
+
+        sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
+
+        ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
+        verify(sendgridService).sendEmailUsingTemplateWithAttachments(
+            eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
+            eq("authorisation"),
+            sendgridEmailConfigCaptor.capture()
+        );
+        SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
+        assertEquals(1, sendgridEmailConfig.getListOfAttachments().size());
+        assertEquals("matching-doc.pdf",
+                     sendgridEmailConfig.getListOfAttachments().getFirst().getDocumentFileName());
+    }
+
+    @Test
     public void testSendEmailNotificationToCafcassAndOthersC100Case() {
 
         PartyDetails applicant = PartyDetails.builder()

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/sendandreply/SendAndReplyServiceTest.java
@@ -2874,6 +2874,87 @@ public class SendAndReplyServiceTest {
     }
 
     @Test
+    public void testSendEmailNotificationPrefersDatedSavedExternalMessageAttachmentsOverNullUpdatedTime() {
+        PartyDetails applicant = PartyDetails.builder()
+            .partyId(UUID.randomUUID())
+            .representativeFirstName("Abc")
+            .representativeLastName("Xyz")
+            .firstName("Applicant firstname")
+            .lastName("Applicant lastName")
+            .gender(Gender.male)
+            .email("abc@xyz.com")
+            .solicitorEmail("testSolicitor@xyz.com")
+            .phoneNumber("1234567890")
+            .contactPreferences(ContactPreferences.email)
+            .canYouProvideEmailAddress(YesOrNo.Yes)
+            .isEmailAddressConfidential(YesOrNo.Yes)
+            .isPhoneNumberConfidential(YesOrNo.Yes)
+            .solicitorOrg(Organisation.builder().organisationID("ABC").organisationName("XYZ").build())
+            .solicitorAddress(Address.builder().addressLine1("ABC").postCode("AB1 2MN").build())
+            .doTheyHaveLegalRepresentation(YesNoDontKnow.yes)
+            .build();
+
+        Element<PartyDetails> wrappedApplicant = Element.<PartyDetails>builder().id(applicant.getPartyId()).value(
+            applicant).build();
+        DynamicMultiSelectList externalMessageWhoToSendTo = DynamicMultiSelectList.builder()
+            .value(List.of(DynamicMultiselectListElement.builder()
+                               .code(wrappedApplicant.getId().toString())
+                               .label(applicant.getFirstName() + " " + applicant.getLastName())
+                               .build()))
+            .build();
+        uk.gov.hmcts.reform.prl.models.documents.Document nullUpdatedTimeDoc = internalMessageDoc.toBuilder()
+            .documentFileName("null-updated-time-doc.pdf")
+            .build();
+        uk.gov.hmcts.reform.prl.models.documents.Document datedDoc = internalMessageDoc.toBuilder()
+            .documentFileName("dated-doc.pdf")
+            .build();
+
+        Message sendMessageObject = Message.builder()
+            .internalOrExternalMessage(InternalExternalMessageEnum.EXTERNAL)
+            .externalMessageWhoToSendTo(externalMessageWhoToSendTo)
+            .messageAbout(MessageAboutEnum.REVIEW_SUBMITTED_DOCUMENTS)
+            .messageContent("same msg content")
+            .messageSubject("same message subject")
+            .build();
+        Message nullUpdatedTimeSavedMessage = sendMessageObject.toBuilder()
+            .updatedTime(null)
+            .externalMessageAttachDocs(List.of(element(nullUpdatedTimeDoc)))
+            .build();
+        Message datedSavedMessage = sendMessageObject.toBuilder()
+            .updatedTime(dateTime)
+            .externalMessageAttachDocs(List.of(element(datedDoc)))
+            .build();
+
+        CaseData caseDataC100Message = CaseData.builder().id(12345L)
+            .chooseSendOrReply(SEND)
+            .caseTypeOfApplication("C100")
+            .replyMessageDynamicList(DynamicList.builder().build())
+            .applicants(List.of(wrappedApplicant))
+            .respondents(emptyList())
+            .messageContent("same msg content")
+            .sendOrReplyMessage(
+                SendOrReplyMessage.builder()
+                    .sendMessageObject(sendMessageObject)
+                    .respondToMessage(YesOrNo.No)
+                    .messages(List.of(element(nullUpdatedTimeSavedMessage), element(datedSavedMessage)))
+                    .build())
+            .build();
+
+        sendAndReplyService.sendNotificationToExternalParties(caseDataC100Message, "authorisation");
+
+        ArgumentCaptor<SendgridEmailConfig> sendgridEmailConfigCaptor = ArgumentCaptor.forClass(SendgridEmailConfig.class);
+        verify(sendgridService).sendEmailUsingTemplateWithAttachments(
+            eq(SendgridEmailTemplateNames.SEND_EMAIL_TO_EXTERNAL_PARTY),
+            eq("authorisation"),
+            sendgridEmailConfigCaptor.capture()
+        );
+        SendgridEmailConfig sendgridEmailConfig = sendgridEmailConfigCaptor.getValue();
+        assertEquals(1, sendgridEmailConfig.getListOfAttachments().size());
+        assertEquals("dated-doc.pdf",
+                     sendgridEmailConfig.getListOfAttachments().getFirst().getDocumentFileName());
+    }
+
+    @Test
     public void testSendEmailNotificationToCafcassAndOthersC100Case() {
 
         PartyDetails applicant = PartyDetails.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-3385


### Change description ###

## Summary

Fixes external Send and Reply emails so document attachments selected during the journey are included on the email sent to external parties.

The issue was that some selected documents were only available on temporary CCD fields. Those fields can be removed before the SendGrid notification is prepared, so the email could be sent without the expected attachments.

## What changed

- External messages now save all selected attachments onto `externalMessageAttachDocs` when the message is built.
- The saved attachments include:
  - documents selected from the main message screen, such as review submitted documents/application documents
  - documents manually added on the following external attachments screen
- External email notification logic now falls back to the saved message attachments when the temporary attachment fields have already been cleared.
- Added a low-noise SendGrid log showing template name, case reference and attachment count before sending.
- Reverted reply/history changes after confirming external messages are saved as closed and are not part of the reply flow.

## Testing

- Added unit coverage for saving a selected submitted document against an external message.
- Added unit coverage for combining a selected document with a manually added attachment.
- Added unit coverage to confirm external email notifications include selected application documents.
- Added unit coverage to confirm saved external message attachments are used when temporary CCD fields have been removed.
- Existing `SendAndReplyServiceTest` passes.
- `testWithCoverage` reported 90.91%.

## Notes for reviewers

External messages are currently saved as `CLOSED`, so they do not appear in the Reply to a message dropdown. That behaviour has not been changed in this PR.

## Commit to address Del's comment:
Fix external message attachment lookup to use message identifier

External message email notifications now resolve saved attachments by the message identifier copied onto the submitted callback message object.

This avoids relying on subject/content matching or latest-message fallback, which could select attachments from the wrong external message. If the identifier is missing, the email is still sent without recovered saved attachments and a warning is logged.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
