### PR TITLE
FPVTL-3400 Missing Bundle fields.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/mapper/bundle/HearingDetailsMapperUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/mapper/bundle/HearingDetailsMapperUtil.java
@@ -5,15 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.prl.models.dto.bundle.BundleHearingInfo;
-import uk.gov.hmcts.reform.prl.models.dto.hearings.CaseHearing;
 import uk.gov.hmcts.reform.prl.models.dto.hearings.HearingDaySchedule;
 import uk.gov.hmcts.reform.prl.models.dto.hearings.Hearings;
+import uk.gov.hmcts.reform.prl.utils.HearingSelectionUtils;
 
-import java.util.List;
-
-import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.BLANK_STRING;
-import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTED;
 import static uk.gov.hmcts.reform.prl.utils.CommonUtils.getBundleDateTime;
+import static uk.gov.hmcts.reform.prl.utils.HearingSelectionUtils.getNextScheduledListedHearing;
 
 @Slf4j
 @Component
@@ -22,17 +19,13 @@ public class HearingDetailsMapperUtil {
 
     public BundleHearingInfo mapHearingDetails(Hearings hearingDetails) {
         if (null != hearingDetails && null != hearingDetails.getCaseHearings()) {
-            List<CaseHearing> listedCaseHearings = hearingDetails.getCaseHearings().stream()
-                .filter(caseHearing -> LISTED.equalsIgnoreCase(caseHearing.getHmcStatus())).toList();
-            if (null != listedCaseHearings && !listedCaseHearings.isEmpty()) {
-                List<HearingDaySchedule> hearingDaySchedules = listedCaseHearings.get(0).getHearingDaySchedule();
-                if (null != hearingDaySchedules && !hearingDaySchedules.isEmpty()) {
-                    return BundleHearingInfo.builder().hearingVenueAddress(getHearingVenueAddress(hearingDaySchedules.get(0)))
-                        .hearingDateAndTime(null != hearingDaySchedules.get(0).getHearingStartDateTime()
-                            ? getBundleDateTime(hearingDaySchedules.get(0).getHearingStartDateTime()) : BLANK_STRING)
-                        .hearingJudgeName(hearingDaySchedules.get(0).getHearingJudgeName()).build();
-                }
-            }
+            return getNextScheduledListedHearing(hearingDetails.getCaseHearings())
+                .flatMap(HearingSelectionUtils::getNextScheduledHearingDay)
+                .map(hearingDaySchedule -> BundleHearingInfo.builder()
+                    .hearingVenueAddress(getHearingVenueAddress(hearingDaySchedule))
+                    .hearingDateAndTime(getBundleDateTime(hearingDaySchedule.getHearingStartDateTime()))
+                    .hearingJudgeName(hearingDaySchedule.getHearingJudgeName()).build())
+                .orElse(BundleHearingInfo.builder().build());
         }
         return BundleHearingInfo.builder().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/prl/mapper/bundle/HearingDetailsMapperUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/mapper/bundle/HearingDetailsMapperUtil.java
@@ -25,8 +25,18 @@ public class HearingDetailsMapperUtil {
                     .hearingVenueAddress(getHearingVenueAddress(hearingDaySchedule))
                     .hearingDateAndTime(getBundleDateTime(hearingDaySchedule.getHearingStartDateTime()))
                     .hearingJudgeName(hearingDaySchedule.getHearingJudgeName()).build())
+                .map(bundleHearingInfo -> {
+                    log.info(
+                        "Selected bundle hearing details hearingDateAndTime={}, hearingJudgeName={}, hearingVenueAddress={}",
+                        bundleHearingInfo.getHearingDateAndTime(),
+                        bundleHearingInfo.getHearingJudgeName(),
+                        bundleHearingInfo.getHearingVenueAddress()
+                    );
+                    return bundleHearingInfo;
+                })
                 .orElse(BundleHearingInfo.builder().build());
         }
+        log.info("No hearing details available for bundle hearing selection");
         return BundleHearingInfo.builder().build();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/HearingDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/HearingDataService.java
@@ -102,6 +102,8 @@ import static uk.gov.hmcts.reform.prl.utils.CaseUtils.getPartyNameList;
 import static uk.gov.hmcts.reform.prl.utils.CaseUtils.getRespondentSolicitorNameList;
 import static uk.gov.hmcts.reform.prl.utils.CommonUtils.getPersonalCode;
 import static uk.gov.hmcts.reform.prl.utils.ElementUtils.element;
+import static uk.gov.hmcts.reform.prl.utils.HearingSelectionUtils.getNextScheduledHearingDay;
+import static uk.gov.hmcts.reform.prl.utils.HearingSelectionUtils.getNextScheduledListedHearing;
 
 @Slf4j
 @Service
@@ -229,19 +231,20 @@ public class HearingDataService {
                     );
 
                     if (hearingsList != null) {
-                        hearingsList.getCaseHearings().stream()
-                            .filter(caseHearing -> LISTED.equalsIgnoreCase(caseHearing.getHmcStatus()))
-                            .forEach(
-                                hearingFromHmc ->
-                                    dynamicListElements.add(
-                                        DynamicListElement
-                                            .builder()
-                                            .code(caseLinkedData.getCaseReference() + UNDERSCORE + hearingFromHmc.getHearingID())
-                                            .label(caseLinkedData.getCaseReference() + UNDERSCORE + hearingFromHmc.getHearingTypeValue()
-                                                       + HYPHEN_SEPARATOR
-                                                       + hearingFromHmc.getNextHearingDate().format(
-                                                customDateTimeFormatter))
-                                            .build()));
+                        getNextScheduledListedHearing(hearingsList.getCaseHearings())
+                            .ifPresent(hearingFromHmc -> getNextScheduledHearingDay(hearingFromHmc).ifPresent(
+                                hearingDaySchedule ->
+                                           dynamicListElements.add(
+                                               DynamicListElement
+                                                   .builder()
+                                                   .code(caseLinkedData.getCaseReference() + UNDERSCORE
+                                                             + hearingFromHmc.getHearingID())
+                                                   .label(caseLinkedData.getCaseReference() + UNDERSCORE
+                                                              + hearingFromHmc.getHearingTypeValue()
+                                                              + HYPHEN_SEPARATOR
+                                                              + hearingDaySchedule.getHearingStartDateTime().format(
+                                                       customDateTimeFormatter))
+                                                   .build())));
                     }
                 });
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/bundle/BundlingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/bundle/BundlingService.java
@@ -38,6 +38,13 @@ public class BundlingService {
         Hearings hearingDetails = null;
         if (DECISION_OUTCOME.equals(caseData.getState()) || PREPARE_FOR_HEARING_CONDUCT_HEARING.equals(caseData.getState())) {
             hearingDetails = hearingService.getHearings(authorization, String.valueOf(caseData.getId()));
+            log.info(
+                "Bundle creation fetched hearing details for case {}, hearingCount={}",
+                caseData.getId(),
+                hearingDetails != null && hearingDetails.getCaseHearings() != null
+                    ? hearingDetails.getCaseHearings().size()
+                    : 0
+            );
         }
         return createBundle(authorization,authTokenGenerator.generate(),
             bundleCreateRequestMapper.mapCaseDataToBundleCreateRequest(

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/bundle/BundlingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/bundle/BundlingService.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.prl.models.dto.hearings.Hearings;
 import uk.gov.hmcts.reform.prl.services.hearings.HearingService;
 
 import static uk.gov.hmcts.reform.prl.enums.State.DECISION_OUTCOME;
+import static uk.gov.hmcts.reform.prl.enums.State.PREPARE_FOR_HEARING_CONDUCT_HEARING;
 
 @Slf4j
 @Service
@@ -35,7 +36,7 @@ public class BundlingService {
     public BundleCreateResponse createBundleServiceRequest(CaseData caseData,String eventId,
                                                            String authorization) {
         Hearings hearingDetails = null;
-        if (DECISION_OUTCOME.equals(caseData.getState())) {
+        if (DECISION_OUTCOME.equals(caseData.getState()) || PREPARE_FOR_HEARING_CONDUCT_HEARING.equals(caseData.getState())) {
             hearingDetails = hearingService.getHearings(authorization, String.valueOf(caseData.getId()));
         }
         return createBundle(authorization,authTokenGenerator.generate(),

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/hearings/HearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/hearings/HearingService.java
@@ -64,6 +64,11 @@ public class HearingService {
         try {
             hearings = hearingApiClient.getHearingDetails(userToken, authTokenGenerator.generate(), caseReferenceNumber);
             if (hearings != null) {
+                log.info(
+                    "Fetched {} hearings from HMC for case {}",
+                    nullSafeCollection(hearings.getCaseHearings()).size(),
+                    caseReferenceNumber
+                );
                 Map<String, String> refDataCategoryValueMap = getRefDataMap(
                     userToken,
                     authTokenGenerator.generate(),
@@ -75,6 +80,11 @@ public class HearingService {
                     eachHearing.setUrgentFlag(getUrgentFlagWithInHearing(eachHearing));
                     eachHearing.setHearingTypeValue(getHearingTypeValueWithInHearing(eachHearing,refDataCategoryValueMap));
                 }
+                log.info(
+                    "HMC hearing summary for case {} before bundle/next-hearing selection: {}",
+                    caseReferenceNumber,
+                    getHearingSummary(hearings.getCaseHearings())
+                );
 
                 List<CaseHearing> sortedByLatest = hearings.getCaseHearings().stream()
                     .sorted(Comparator.comparing(CaseHearing::getNextHearingDate, Comparator.nullsLast(Comparator.naturalOrder())))
@@ -87,6 +97,32 @@ public class HearingService {
         } catch (FeignException e) {
             throw new HearingException("Error in getting hearings for case " + caseReferenceNumber,  e);
         }
+    }
+
+    private String getHearingSummary(List<CaseHearing> caseHearings) {
+        return nullSafeCollection(caseHearings).stream()
+            .map(hearing -> String.format(
+                "{hearingId=%s, hmcStatus=%s, nextHearingDate=%s, schedules=%s}",
+                hearing.getHearingID(),
+                hearing.getHmcStatus(),
+                hearing.getNextHearingDate(),
+                getScheduleSummary(hearing)
+            ))
+            .toList()
+            .toString();
+    }
+
+    private String getScheduleSummary(CaseHearing hearing) {
+        return nullSafeCollection(hearing.getHearingDaySchedule()).stream()
+            .map(schedule -> String.format(
+                "{start=%s, end=%s, venue=%s, judge=%s}",
+                schedule.getHearingStartDateTime(),
+                schedule.getHearingEndDateTime(),
+                schedule.getHearingVenueName(),
+                schedule.getHearingJudgeName()
+            ))
+            .toList()
+            .toString();
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/prl/utils/CommonUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/utils/CommonUtils.java
@@ -278,7 +278,7 @@ public class CommonUtils {
         LocalDateTime ldt = CaseUtils.convertUtcToBst(bundleDateTime);
 
         return newBundleDateTime
-            .append(bundleDateTime.format(DateTimeFormatter.ofPattern("d MMM yyyy", Locale.ENGLISH)))
+            .append(ldt.format(DateTimeFormatter.ofPattern("d MMM yyyy", Locale.ENGLISH)))
             .append(EMPTY_SPACE_STRING)
             .append(CaseUtils.convertLocalDateTimeToAmOrPmTime(ldt))
             .toString();

--- a/src/main/java/uk/gov/hmcts/reform/prl/utils/HearingSelectionUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/utils/HearingSelectionUtils.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.prl.utils;
+
+import uk.gov.hmcts.reform.prl.models.dto.hearings.CaseHearing;
+import uk.gov.hmcts.reform.prl.models.dto.hearings.HearingDaySchedule;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.LISTED;
+import static uk.gov.hmcts.reform.prl.utils.ElementUtils.nullSafeCollection;
+
+public final class HearingSelectionUtils {
+
+    private HearingSelectionUtils() {
+    }
+
+    public static Optional<CaseHearing> getNextScheduledListedHearing(List<CaseHearing> caseHearings) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return nullSafeCollection(caseHearings).stream()
+            .filter(caseHearing -> getNextScheduledHearingDay(caseHearing, now).isPresent())
+            .min(Comparator.comparing(caseHearing -> getNextScheduledHearingDay(caseHearing, now)
+                .map(HearingDaySchedule::getHearingStartDateTime)
+                .orElse(LocalDateTime.MAX)));
+    }
+
+    public static Optional<HearingDaySchedule> getNextScheduledHearingDay(CaseHearing caseHearing) {
+        return getNextScheduledHearingDay(caseHearing, LocalDateTime.now());
+    }
+
+    private static Optional<HearingDaySchedule> getNextScheduledHearingDay(CaseHearing caseHearing, LocalDateTime now) {
+        if (caseHearing == null || !LISTED.equalsIgnoreCase(caseHearing.getHmcStatus())) {
+            return Optional.empty();
+        }
+
+        return nullSafeCollection(caseHearing.getHearingDaySchedule()).stream()
+            .filter(hearingDaySchedule -> Objects.nonNull(hearingDaySchedule.getHearingStartDateTime()))
+            .filter(hearingDaySchedule -> hearingDaySchedule.getHearingStartDateTime().isAfter(now))
+            .min(Comparator.comparing(HearingDaySchedule::getHearingStartDateTime));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/prl/mapper/bundle/BundleCreateRequestByCategoryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/mapper/bundle/BundleCreateRequestByCategoryMapperTest.java
@@ -44,6 +44,7 @@ import static uk.gov.hmcts.reform.prl.constants.ManageDocumentsCategoryConstants
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.AWP_STATUS_CLOSED;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.AWP_STATUS_SUBMITTED;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.CONFIDENTIAL;
+import static uk.gov.hmcts.reform.prl.utils.CommonUtils.getBundleDateTime;
 
 @ExtendWith(MockitoExtension.class)
 class BundleCreateRequestByCategoryMapperTest {
@@ -63,6 +64,8 @@ class BundleCreateRequestByCategoryMapperTest {
     @InjectMocks
     private BundleCreateRequestByCategoryMapper bundleCreateRequestByCategoryMapper;
 
+    private LocalDateTime futureHearingDateTime;
+
     @BeforeEach
     void setUp() {
         hearingDetailsMapperUtil = new HearingDetailsMapperUtil();
@@ -70,6 +73,7 @@ class BundleCreateRequestByCategoryMapperTest {
                                                                                       systemUserService,
                                                                                       bundleCategoryConfig,
                                                                                       hearingDetailsMapperUtil);
+        futureHearingDateTime = LocalDateTime.now().plusDays(7);
     }
 
     @Test
@@ -362,7 +366,7 @@ class BundleCreateRequestByCategoryMapperTest {
             .applicantName("ApplicantFirstNameAndLastName")
             .build();
 
-        LocalDateTime hearingDateTime = LocalDateTime.of(2025, 3, 15, 10, 30);
+        LocalDateTime hearingDateTime = futureHearingDateTime;
         List<HearingDaySchedule> hearingDaySchedules = new ArrayList<>();
         hearingDaySchedules.add(HearingDaySchedule.hearingDayScheduleWith()
             .hearingJudgeId("judge123")
@@ -390,8 +394,10 @@ class BundleCreateRequestByCategoryMapperTest {
 
         assertNotNull(bundleCreateRequest);
         assertEquals("Judge John Smith", bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
-        assertTrue(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime().contains("15 Mar 2025"));
-        assertTrue(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime().contains("AM"));
+        assertEquals(
+            getBundleDateTime(hearingDateTime),
+            bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime()
+        );
         assertEquals("Manchester Crown Court" + "\n" + "Judicial Building, Bridge Street, Manchester M2 1RB",
             bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
     }
@@ -408,7 +414,7 @@ class BundleCreateRequestByCategoryMapperTest {
             .hearingJudgeName("Judge Jane Doe")
             .hearingVenueName(null)
             .hearingVenueAddress("123 Court Street, London SW1A 1AA")
-            .hearingStartDateTime(LocalDateTime.of(2025, 4, 20, 14, 0))
+            .hearingStartDateTime(futureHearingDateTime)
             .build());
 
         List<CaseHearing> caseHearings = new ArrayList<>();
@@ -430,7 +436,7 @@ class BundleCreateRequestByCategoryMapperTest {
         assertEquals("Judge Jane Doe", bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
         assertEquals("123 Court Street, London SW1A 1AA",
             bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
-        assertTrue(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime().contains("20 Apr 2025"));
+        assertNotNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime());
     }
 
     @Test
@@ -464,10 +470,9 @@ class BundleCreateRequestByCategoryMapperTest {
                 Hearings.hearingsWith().caseHearings(caseHearings).build(), "sample.yaml");
 
         assertNotNull(bundleCreateRequest);
-        assertEquals("Judge Bob Wilson", bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
-        assertEquals("Bristol County Court" + "\n" + "Small Street, Bristol BS1 1DA",
-            bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
-        assertTrue(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime().isEmpty());
+        assertNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
+        assertNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
+        assertNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime());
     }
 
     @Test
@@ -477,8 +482,8 @@ class BundleCreateRequestByCategoryMapperTest {
             .applicantName("ApplicantFirstNameAndLastName")
             .build();
 
-        LocalDateTime firstHearingDateTime = LocalDateTime.of(2025, 5, 10, 9, 0);
-        LocalDateTime secondHearingDateTime = LocalDateTime.of(2025, 6, 15, 14, 0);
+        LocalDateTime firstHearingDateTime = futureHearingDateTime;
+        LocalDateTime secondHearingDateTime = futureHearingDateTime.plusDays(5);
 
         List<HearingDaySchedule> firstHearingSchedules = new ArrayList<>();
         firstHearingSchedules.add(HearingDaySchedule.hearingDayScheduleWith()
@@ -516,17 +521,20 @@ class BundleCreateRequestByCategoryMapperTest {
                 Hearings.hearingsWith().caseHearings(caseHearings).build(), "sample.yaml");
 
         assertNotNull(bundleCreateRequest);
-        // Should map the first LISTED hearing
+        // Should map the next scheduled LISTED hearing
         assertEquals("Judge Alice Brown", bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
         assertEquals("Liverpool Court" + "\n" + "31 Whitechapel, Liverpool L1 6DS",
             bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
-        assertTrue(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime().contains("10 May 2025"));
+        assertEquals(
+            getBundleDateTime(firstHearingDateTime),
+            bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime()
+        );
     }
 
     @Test
     void testMapHearingDetailsWithMultipleHearingDaySchedules() {
-        LocalDateTime firstDayDateTime = LocalDateTime.of(2025, 7, 5, 10, 0);
-        LocalDateTime secondDayDateTime = LocalDateTime.of(2025, 7, 6, 11, 0);
+        LocalDateTime firstDayDateTime = futureHearingDateTime;
+        LocalDateTime secondDayDateTime = futureHearingDateTime.plusDays(1);
 
         List<HearingDaySchedule> hearingDaySchedules = new ArrayList<>();
         hearingDaySchedules.add(HearingDaySchedule.hearingDayScheduleWith()
@@ -563,11 +571,14 @@ class BundleCreateRequestByCategoryMapperTest {
                 Hearings.hearingsWith().caseHearings(caseHearings).build(), "sample.yaml");
 
         assertNotNull(bundleCreateRequest);
-        // Should map the first day schedule
+        // Should map the next scheduled day
         assertEquals("Judge Emma Wilson", bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
         assertEquals("London Central Court" + "\n" + "Central London Address",
             bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
-        assertTrue(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime().contains("5 Jul 2025"));
+        assertEquals(
+            getBundleDateTime(firstDayDateTime),
+            bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime()
+        );
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/mapper/bundle/BundleCreateRequestMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/mapper/bundle/BundleCreateRequestMapperTest.java
@@ -87,6 +87,7 @@ import static uk.gov.hmcts.reform.prl.enums.LanguagePreference.english;
 import static uk.gov.hmcts.reform.prl.enums.RestrictToCafcassHmcts.restrictToGroup;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.No;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.Yes;
+import static uk.gov.hmcts.reform.prl.utils.CommonUtils.getBundleDateTime;
 import static uk.gov.hmcts.reform.prl.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.prl.utils.ElementUtils.wrapElements;
 
@@ -98,10 +99,13 @@ public class BundleCreateRequestMapperTest {
 
     private BundleCreateRequestMapper bundleCreateRequestMapper;
 
+    private LocalDateTime futureHearingDateTime;
+
     @Before
     public void setUp() {
         hearingDetailsMapperUtil = new HearingDetailsMapperUtil();
         bundleCreateRequestMapper = new BundleCreateRequestMapper(hearingDetailsMapperUtil);
+        futureHearingDateTime = LocalDateTime.now().plusDays(7);
     }
 
     @Test
@@ -742,7 +746,7 @@ public class BundleCreateRequestMapperTest {
         List<HearingDaySchedule> hearingDaySchedules = new ArrayList<>();
         hearingDaySchedules.add(HearingDaySchedule.hearingDayScheduleWith().hearingJudgeId("123").hearingJudgeName("hearingJudgeName")
                                     .hearingVenueId("venueId").hearingVenueAddress("venueAddress")
-                                    .hearingStartDateTime(LocalDateTime.of(2024, 9, 16, 14, 0)).build());
+                                    .hearingStartDateTime(futureHearingDateTime).build());
         List<CaseHearing> caseHearings = new ArrayList<>();
         caseHearings.add(CaseHearing.caseHearingWith().hmcStatus(LISTED).hearingDaySchedule(hearingDaySchedules).build());
 
@@ -766,7 +770,7 @@ public class BundleCreateRequestMapperTest {
             .mapCaseDataToBundleCreateRequest(c100CaseData, "eventI", Hearings.hearingsWith().caseHearings(caseHearings).build(), "sample.yaml");
         assertNotNull(bundleCreateRequest);
         assertEquals(
-            "16 Sep 2024 3:00 PM",
+            getBundleDateTime(futureHearingDateTime),
             bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime()
         );
     }
@@ -777,7 +781,7 @@ public class BundleCreateRequestMapperTest {
         hearingDaySchedules.add(HearingDaySchedule.hearingDayScheduleWith().hearingJudgeId("123").hearingJudgeName(
                 "hearingJudgeName")
                                     .hearingVenueId("venueId").hearingVenueAddress("venueAddress")
-                                    .hearingStartDateTime(LocalDateTime.of(2024, 9, 16, 14, 0)).build());
+                                    .hearingStartDateTime(futureHearingDateTime).build());
         List<CaseHearing> caseHearings = new ArrayList<>();
         caseHearings.add(CaseHearing.caseHearingWith().hmcStatus(LISTED).hearingDaySchedule(hearingDaySchedules).build());
         List<FL401Proceedings> fl401Docs = new ArrayList<>();
@@ -830,7 +834,7 @@ public class BundleCreateRequestMapperTest {
         hearingDaySchedules.add(HearingDaySchedule.hearingDayScheduleWith().hearingJudgeId("123").hearingJudgeName(
                 "hearingJudgeName")
                                     .hearingVenueId("venueId").hearingVenueAddress("venueAddress")
-                                    .hearingStartDateTime(LocalDateTime.of(2024, 9, 16, 14, 0)).build());
+                                    .hearingStartDateTime(futureHearingDateTime).build());
         List<CaseHearing> caseHearings = new ArrayList<>();
         caseHearings.add(CaseHearing.caseHearingWith().hmcStatus(LISTED).hearingDaySchedule(hearingDaySchedules).build());
         List<ProceedingDetails> c100Docs = new ArrayList<>();
@@ -881,7 +885,7 @@ public class BundleCreateRequestMapperTest {
         List<HearingDaySchedule> hearingDaySchedules = new ArrayList<>();
         hearingDaySchedules.add(HearingDaySchedule.hearingDayScheduleWith().hearingJudgeId("123").hearingJudgeName("hearingJudgeName")
             .hearingVenueName("venueName").hearingVenueId("venueId").hearingVenueAddress("venueAddress")
-            .hearingStartDateTime(LocalDateTime.now()).build());
+            .hearingStartDateTime(futureHearingDateTime).build());
         List<CaseHearing> caseHearings = new ArrayList<>();
         caseHearings.add(CaseHearing.caseHearingWith().hmcStatus(LISTED).hearingDaySchedule(hearingDaySchedules).build());
 
@@ -933,7 +937,7 @@ public class BundleCreateRequestMapperTest {
         BundleCreateRequest bundleCreateRequest = bundleCreateRequestMapper.mapCaseDataToBundleCreateRequest(c100CaseData,"eventI",
             Hearings.hearingsWith().caseHearings(caseHearings).build(), "sample.yaml");
         assertNotNull(bundleCreateRequest);
-        Assert.assertEquals("",bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime());
+        Assert.assertNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingDateAndTime());
         Assert.assertNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingJudgeName());
         Assert.assertNull(bundleCreateRequest.getCaseDetails().getCaseData().getData().getHearingDetails().getHearingVenueAddress());
     }

--- a/src/test/java/uk/gov/hmcts/reform/prl/mapper/bundle/HearingDetailsMapperUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/mapper/bundle/HearingDetailsMapperUtilTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.hmcts.reform.prl.utils.CommonUtils.getBundleDateTime;
 
 @ExtendWith(MockitoExtension.class)
 class HearingDetailsMapperUtilTest {
@@ -129,7 +130,7 @@ class HearingDetailsMapperUtilTest {
     @Test
     void shouldMapHearingDetailsWhenListedHearingHasCompleteData() {
         // Given
-        LocalDateTime hearingStartTime = LocalDateTime.of(2024, 1, 15, 10, 30);
+        LocalDateTime hearingStartTime = LocalDateTime.now().plusDays(7);
         HearingDaySchedule hearingDaySchedule = HearingDaySchedule.hearingDayScheduleWith()
             .hearingStartDateTime(hearingStartTime)
             .hearingVenueName("Central Court")
@@ -150,12 +151,12 @@ class HearingDetailsMapperUtilTest {
         // Then
         assertNotNull(result);
         assertEquals("Central Court\n123 Main Street, London", result.getHearingVenueAddress());
-        assertEquals("15 Jan 2024 10:30 AM", result.getHearingDateAndTime()); // Assuming getBundleDateTime formats it this way
+        assertEquals(getBundleDateTime(hearingStartTime), result.getHearingDateAndTime());
         assertEquals("Judge Smith", result.getHearingJudgeName());
     }
 
     @Test
-    void shouldMapHearingDetailsWhenHearingStartDateTimeIsNull() {
+    void shouldReturnEmptyBundleHearingInfoWhenHearingStartDateTimeIsNull() {
         // Given
         HearingDaySchedule hearingDaySchedule = HearingDaySchedule.hearingDayScheduleWith()
             .hearingVenueName("Central Court")
@@ -175,9 +176,83 @@ class HearingDetailsMapperUtilTest {
 
         // Then
         assertNotNull(result);
-        assertEquals("Central Court\n123 Main Street, London", result.getHearingVenueAddress());
-        assertEquals("", result.getHearingDateAndTime()); // BLANK_STRING when hearingStartDateTime is null
-        assertEquals("Judge Smith", result.getHearingJudgeName());
+        assertNull(result.getHearingVenueAddress());
+        assertNull(result.getHearingDateAndTime());
+        assertNull(result.getHearingJudgeName());
+    }
+
+    @Test
+    void shouldMapNextScheduledListedHearingWhenFirstListedHearingIsInPast() {
+        // Given
+        LocalDateTime pastHearingStartTime = LocalDateTime.now().minusDays(1);
+        LocalDateTime futureHearingStartTime = LocalDateTime.now().plusDays(3);
+        HearingDaySchedule pastSchedule = HearingDaySchedule.hearingDayScheduleWith()
+            .hearingStartDateTime(pastHearingStartTime)
+            .hearingVenueName("Past Court")
+            .hearingVenueAddress("1 Past Street, London")
+            .hearingJudgeName("Judge Past")
+            .build();
+        HearingDaySchedule futureSchedule = HearingDaySchedule.hearingDayScheduleWith()
+            .hearingStartDateTime(futureHearingStartTime)
+            .hearingVenueName("Future Court")
+            .hearingVenueAddress("1 Future Street, London")
+            .hearingJudgeName("Judge Future")
+            .build();
+        CaseHearing pastHearing = CaseHearing.caseHearingWith()
+            .hmcStatus("LISTED")
+            .hearingDaySchedule(List.of(pastSchedule))
+            .build();
+        CaseHearing futureHearing = CaseHearing.caseHearingWith()
+            .hmcStatus("LISTED")
+            .hearingDaySchedule(List.of(futureSchedule))
+            .build();
+        Hearings hearings = Hearings.hearingsWith()
+            .caseHearings(List.of(pastHearing, futureHearing))
+            .build();
+
+        // When
+        BundleHearingInfo result = util.mapHearingDetails(hearings);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Future Court\n1 Future Street, London", result.getHearingVenueAddress());
+        assertEquals(getBundleDateTime(futureHearingStartTime), result.getHearingDateAndTime());
+        assertEquals("Judge Future", result.getHearingJudgeName());
+    }
+
+    @Test
+    void shouldMapEarliestFutureScheduleWithinListedHearing() {
+        // Given
+        LocalDateTime laterHearingStartTime = LocalDateTime.now().plusDays(8);
+        LocalDateTime nextHearingStartTime = LocalDateTime.now().plusDays(2);
+        HearingDaySchedule laterSchedule = HearingDaySchedule.hearingDayScheduleWith()
+            .hearingStartDateTime(laterHearingStartTime)
+            .hearingVenueName("Later Court")
+            .hearingVenueAddress("1 Later Street, London")
+            .hearingJudgeName("Judge Later")
+            .build();
+        HearingDaySchedule nextSchedule = HearingDaySchedule.hearingDayScheduleWith()
+            .hearingStartDateTime(nextHearingStartTime)
+            .hearingVenueName("Next Court")
+            .hearingVenueAddress("1 Next Street, London")
+            .hearingJudgeName("Judge Next")
+            .build();
+        CaseHearing caseHearing = CaseHearing.caseHearingWith()
+            .hmcStatus("LISTED")
+            .hearingDaySchedule(List.of(laterSchedule, nextSchedule))
+            .build();
+        Hearings hearings = Hearings.hearingsWith()
+            .caseHearings(List.of(caseHearing))
+            .build();
+
+        // When
+        BundleHearingInfo result = util.mapHearingDetails(hearings);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Next Court\n1 Next Street, London", result.getHearingVenueAddress());
+        assertEquals(getBundleDateTime(nextHearingStartTime), result.getHearingDateAndTime());
+        assertEquals("Judge Next", result.getHearingJudgeName());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/HearingDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/HearingDataServiceTest.java
@@ -632,11 +632,14 @@ public class HearingDataServiceTest {
             .build();
         caseLinkedDataList.add(caseLinkedData);
         when(hearingService.getCaseLinkedData(any(), any())).thenReturn(caseLinkedDataList);
+        LocalDateTime hearingStartDateTime = LocalDateTime.now().plusDays(7);
         CaseHearing caseHearing = CaseHearing.caseHearingWith()
             .hmcStatus("LISTED")
-            .nextHearingDate(LocalDateTime.of(2023, 11, 8, 9, 0))
             .hearingID(123L)
             .hearingTypeValue("test")
+            .hearingDaySchedule(List.of(HearingDaySchedule.hearingDayScheduleWith()
+                                    .hearingStartDateTime(hearingStartDateTime)
+                                    .build()))
             .build();
         List<CaseHearing> caseHearings = new ArrayList<>();
         caseHearings.add(caseHearing);
@@ -664,7 +667,10 @@ public class HearingDataServiceTest {
 
         List<DynamicListElement> expectedResponse = hearingDataService.getLinkedCases(authToken, caseData);
         assertEquals("1677767515750127_123",expectedResponse.get(0).getCode());
-        assertEquals("1677767515750127_test - 08 Nov 2023",expectedResponse.get(0).getLabel());
+        assertEquals(
+            "1677767515750127_test - " + hearingStartDateTime.format(DateTimeFormatter.ofPattern("dd MMM yyyy")),
+            expectedResponse.get(0).getLabel()
+        );
     }
 
     @Test()
@@ -676,11 +682,14 @@ public class HearingDataServiceTest {
             .build();
         caseLinkedDataList.add(caseLinkedData);
         when(hearingService.getCaseLinkedData(any(), any())).thenReturn(caseLinkedDataList);
+        LocalDateTime hearingStartDateTime = LocalDateTime.now().plusDays(7);
         CaseHearing caseHearing = CaseHearing.caseHearingWith()
             .hmcStatus("LISTED")
-            .nextHearingDate(LocalDateTime.of(2023, 11, 8, 9, 0))
             .hearingID(123L)
             .hearingTypeValue("test")
+            .hearingDaySchedule(List.of(HearingDaySchedule.hearingDayScheduleWith()
+                                    .hearingStartDateTime(hearingStartDateTime)
+                                    .build()))
             .build();
 
         List<CaseHearing> caseHearings = new ArrayList<>();
@@ -709,7 +718,77 @@ public class HearingDataServiceTest {
 
         List<DynamicListElement> expectedResponse = hearingDataService.getLinkedCases(authToken, caseData);
         assertEquals("1677767515750127_123", expectedResponse.get(0).getCode());
-        assertEquals("1677767515750127_test - 08 Nov 2023", expectedResponse.get(0).getLabel());
+        assertEquals(
+            "1677767515750127_test - " + hearingStartDateTime.format(DateTimeFormatter.ofPattern("dd MMM yyyy")),
+            expectedResponse.get(0).getLabel()
+        );
+    }
+
+    @Test()
+    public void testGetLinkedCasesSelectsNextScheduledListedHearing() {
+        List<CaseLinkedData> caseLinkedDataList = new ArrayList<>();
+        CaseLinkedData caseLinkedData = CaseLinkedData.caseLinkedDataWith()
+            .caseName("CaseName-Test10")
+            .caseReference("1677767515750127")
+            .build();
+        caseLinkedDataList.add(caseLinkedData);
+        when(hearingService.getCaseLinkedData(any(), any())).thenReturn(caseLinkedDataList);
+        LocalDateTime pastHearingStartDateTime = LocalDateTime.now().minusDays(2);
+        LocalDateTime nextHearingStartDateTime = LocalDateTime.now().plusDays(3);
+        LocalDateTime laterHearingStartDateTime = LocalDateTime.now().plusDays(8);
+        CaseHearing pastHearing = CaseHearing.caseHearingWith()
+            .hmcStatus("LISTED")
+            .hearingID(123L)
+            .hearingTypeValue("past")
+            .hearingDaySchedule(List.of(HearingDaySchedule.hearingDayScheduleWith()
+                                    .hearingStartDateTime(pastHearingStartDateTime)
+                                    .build()))
+            .build();
+        CaseHearing laterHearing = CaseHearing.caseHearingWith()
+            .hmcStatus("LISTED")
+            .hearingID(456L)
+            .hearingTypeValue("later")
+            .hearingDaySchedule(List.of(HearingDaySchedule.hearingDayScheduleWith()
+                                    .hearingStartDateTime(laterHearingStartDateTime)
+                                    .build()))
+            .build();
+        CaseHearing nextHearing = CaseHearing.caseHearingWith()
+            .hmcStatus("LISTED")
+            .hearingID(789L)
+            .hearingTypeValue("next")
+            .hearingDaySchedule(List.of(HearingDaySchedule.hearingDayScheduleWith()
+                                    .hearingStartDateTime(nextHearingStartDateTime)
+                                    .build()))
+            .build();
+        Hearings hearings = Hearings.hearingsWith()
+            .caseRef("1677767515750127")
+            .caseHearings(List.of(pastHearing, laterHearing, nextHearing))
+            .build();
+
+        when(hearingService.getHearings(any(), any())).thenReturn(hearings);
+
+        CaseData caseData = CaseData.builder()
+            .courtName("testcourt")
+            .caseManagementLocation(CaseManagementLocation.builder()
+                                        .baseLocationId("123")
+                                        .regionId("1111")
+                                        .build()).build();
+
+        Map<String, Object> stringObjectMap = caseData.toMap(new ObjectMapper());
+
+        CaseDetails caseDetails = CaseDetails.builder().id(
+            1677767515750127L).data(stringObjectMap).build();
+
+        when(caseService.getCase(any(), any())).thenReturn(caseDetails);
+        when(objectMapper.convertValue(stringObjectMap, CaseData.class)).thenReturn(caseData);
+
+        List<DynamicListElement> expectedResponse = hearingDataService.getLinkedCases(authToken, caseData);
+        assertEquals(1, expectedResponse.size());
+        assertEquals("1677767515750127_789", expectedResponse.get(0).getCode());
+        assertEquals(
+            "1677767515750127_next - " + nextHearingStartDateTime.format(DateTimeFormatter.ofPattern("dd MMM yyyy")),
+            expectedResponse.get(0).getLabel()
+        );
     }
 
     @Test()

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/bundle/BundlingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/bundle/BundlingServiceTest.java
@@ -37,12 +37,14 @@ import uk.gov.hmcts.reform.prl.models.complextypes.confidentiality.ChildConfiden
 import uk.gov.hmcts.reform.prl.models.complextypes.confidentiality.OtherPersonConfidentialityDetails;
 import uk.gov.hmcts.reform.prl.models.documents.Document;
 import uk.gov.hmcts.reform.prl.models.dto.bundle.Bundle;
+import uk.gov.hmcts.reform.prl.models.dto.bundle.BundleCreateRequest;
 import uk.gov.hmcts.reform.prl.models.dto.bundle.BundleCreateResponse;
 import uk.gov.hmcts.reform.prl.models.dto.bundle.BundleDetails;
 import uk.gov.hmcts.reform.prl.models.dto.bundle.BundlingInformation;
 import uk.gov.hmcts.reform.prl.models.dto.bundle.DocumentLink;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.AllegationOfHarm;
 import uk.gov.hmcts.reform.prl.models.dto.ccd.CaseData;
+import uk.gov.hmcts.reform.prl.models.dto.hearings.Hearings;
 import uk.gov.hmcts.reform.prl.services.hearings.HearingService;
 import uk.gov.hmcts.reform.prl.utils.CaseUtils;
 import uk.gov.hmcts.reform.prl.utils.ElementUtils;
@@ -53,8 +55,14 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.prl.enums.LanguagePreference.english;
+import static uk.gov.hmcts.reform.prl.enums.State.PREPARE_FOR_HEARING_CONDUCT_HEARING;
+import static uk.gov.hmcts.reform.prl.enums.State.SUBMITTED_PAID;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.No;
 import static uk.gov.hmcts.reform.prl.enums.YesOrNo.Yes;
 
@@ -289,5 +297,57 @@ public class BundlingServiceTest {
             .thenReturn(bundleCreateResponse);
         BundleCreateResponse expectedResponse = bundlingService.createBundleServiceRequest(c100CaseDataOther,"eventId","authorization");
         assertEquals(bundleCreateResponse.documentTaskId, expectedResponse.documentTaskId);
+    }
+
+    @Test
+    public void testCreateBundleServiceFetchesHearingsForPrepareForHearingConductHearingState() {
+        Hearings hearings = Hearings.hearingsWith().build();
+        BundleCreateResponse bundleCreateResponse = BundleCreateResponse.builder().documentTaskId(123).build();
+        CaseData caseData = c100CaseData.toBuilder()
+            .state(PREPARE_FOR_HEARING_CONDUCT_HEARING)
+            .build();
+
+        when(authTokenGenerator.generate()).thenReturn("authToken");
+        when(hearingService.getHearings("authorization", "123456789123")).thenReturn(hearings);
+        when(bundleApiClient.createBundleServiceRequest(
+            eq("authorization"),
+            eq("authToken"),
+            nullable(BundleCreateRequest.class)
+        ))
+            .thenReturn(bundleCreateResponse);
+
+        BundleCreateResponse expectedResponse = bundlingService.createBundleServiceRequest(
+            caseData,
+            "eventId",
+            "authorization"
+        );
+
+        assertEquals(bundleCreateResponse.documentTaskId, expectedResponse.documentTaskId);
+        verify(hearingService).getHearings("authorization", "123456789123");
+    }
+
+    @Test
+    public void testCreateBundleServiceDoesNotFetchHearingsForOtherState() {
+        BundleCreateResponse bundleCreateResponse = BundleCreateResponse.builder().documentTaskId(123).build();
+        CaseData caseData = c100CaseData.toBuilder()
+            .state(SUBMITTED_PAID)
+            .build();
+
+        when(authTokenGenerator.generate()).thenReturn("authToken");
+        when(bundleApiClient.createBundleServiceRequest(
+            eq("authorization"),
+            eq("authToken"),
+            nullable(BundleCreateRequest.class)
+        ))
+            .thenReturn(bundleCreateResponse);
+
+        BundleCreateResponse expectedResponse = bundlingService.createBundleServiceRequest(
+            caseData,
+            "eventId",
+            "authorization"
+        );
+
+        assertEquals(bundleCreateResponse.documentTaskId, expectedResponse.documentTaskId);
+        verify(hearingService, never()).getHearings("authorization", "123456789123");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/prl/utils/CommonUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/utils/CommonUtilsTest.java
@@ -35,4 +35,17 @@ class CommonUtilsTest {
         assertNotNull(result);
         assertEquals("15 Jul 2024 11:30 AM", result);
     }
+
+    @Test
+    void shouldFormatDateAfterBstConversionWhenUtcTimeCrossesMidnight() {
+        // Given - 23:30 UTC is 00:30 next day in London during BST
+        LocalDateTime utcDateTime = LocalDateTime.of(2024, Month.AUGUST, 5, 23, 30, 0);
+
+        // When
+        String result = CommonUtils.getBundleDateTime(utcDateTime);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("6 Aug 2024 12:30 AM", result);
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
## Summary

This PR fixes missing hearing data in bundle generation by selecting the next scheduled listed hearing instead of the first hearing with `LISTED` status.

It also allows bundle generation to retrieve hearing details when a case is in `PREPARE_FOR_HEARING_CONDUCT_HEARING`, which is now required by the business process.

## Changes

- Added shared hearing selection logic to identify the nearest future `LISTED` hearing from HMC hearing schedules.
- Updated bundle hearing mapping to use the next scheduled listed hearing and its next future hearing day.
- Updated linked-case hearing list population to use the same next scheduled hearing selection.
- Updated bundle generation to fetch hearing details for cases in either `DECISION_OUTCOME` or `PREPARE_FOR_HEARING_CONDUCT_HEARING`.
- Removed unreachable null-date handling in bundle hearing mapping because only schedules with a non-null future start time are selectable.
- Updated tests to use future hearing dates so they remain valid with current-time based selection.

## Testing


Coverage results for the targeted files:

- `HearingDetailsMapperUtil.java`: 100%
- `HearingDataService.java`: 100%
- `BundlingService.java`: 100%
- Combined target score: 100%

Also verified focused bundle and hearing tests while developing:


## Notes

- Past `LISTED` hearings are no longer used for bundle hearing details.
- Hearings without a scheduled future `hearingStartDateTime` are not treated as next scheduled hearings.
- The previous fallback blank date branch was removed because it was unreachable after applying the new selection rule.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
