### PR TITLE
FPVTL-3443: Improve C100 resubmission document generation performance

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/prl/config/DocumentGenerationExecutorConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/config/DocumentGenerationExecutorConfig.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.prl.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+public class DocumentGenerationExecutorConfig {
+
+    public static final String RESUBMISSION_DOCUMENT_EXECUTOR = "resubmissionDocumentExecutor";
+
+    @Bean(name = RESUBMISSION_DOCUMENT_EXECUTOR)
+    public Executor resubmissionDocumentExecutor(
+        @Value("${document-generation.resubmission-concurrency:4}") int concurrency
+    ) {
+        if (concurrency < 1) {
+            throw new IllegalArgumentException("document-generation.resubmission-concurrency must be at least 1");
+        }
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(concurrency);
+        executor.setMaxPoolSize(concurrency);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("resubmission-document-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        return executor;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/prl/controllers/ResubmitApplicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/controllers/ResubmitApplicationController.java
@@ -145,6 +145,11 @@ public class ResubmitApplicationController {
                                             Map<String, Object> caseDataUpdated,
                                             Optional<String> previousStates) throws Exception {
         if (previousStates.isPresent()) {
+            boolean isC100Case = C100_CASE_TYPE.equals(CaseUtils.getCaseTypeOfApplication(caseData));
+            if (isC100Case) {
+                caseData = organisationService.getApplicantOrganisationDetails(caseData);
+                caseData = organisationService.getRespondentOrganisationDetails(caseData);
+            }
             if (State.SUBMITTED_PAID.getValue().equalsIgnoreCase(previousStates.get())) {
                 caseData = caseData.toBuilder().state(State.SUBMITTED_PAID).build();
                 caseDataUpdated.put(STATE_FIELD, State.SUBMITTED_PAID);
@@ -169,8 +174,10 @@ public class ResubmitApplicationController {
             }
             if (State.CASE_ISSUED.getValue().equalsIgnoreCase(previousStates.get())
                 || State.JUDICIAL_REVIEW.getValue().equalsIgnoreCase(previousStates.get())) {
-                caseData = organisationService.getApplicantOrganisationDetails(caseData);
-                caseData = organisationService.getRespondentOrganisationDetails(caseData);
+                if (!isC100Case) {
+                    caseData = organisationService.getApplicantOrganisationDetails(caseData);
+                    caseData = organisationService.getRespondentOrganisationDetails(caseData);
+                }
                 caseData = caseData.setIssueDate();
                 caseData = caseData.toBuilder().state(State.fromValue((previousStates.get()))).build();
 
@@ -184,12 +191,17 @@ public class ResubmitApplicationController {
                 eventPublisher.publishEvent(courtAdminNotificationEmailEvent);
             }
             // All docs will be regenerated in both issue and submitted state jira FPET-21
-            caseDataUpdated.putAll(documentGenService.createUpdatedCaseDataWithDocuments(authorisation, caseData, true));
-            if (C100_CASE_TYPE.equals(CaseUtils.getCaseTypeOfApplication(caseData))) {
+            if (isC100Case) {
+                caseDataUpdated.putAll(documentGenService.createUpdatedCaseDataWithDocumentsForC100Resubmission(
+                    authorisation,
+                    caseData
+                ));
                 caseDataUpdated.putAll(documentGenService.generateDraftDocumentsForC100CaseResubmission(
                     authorisation,
                     caseData
                 ));
+            } else {
+                caseDataUpdated.putAll(documentGenService.createUpdatedCaseDataWithDocuments(authorisation, caseData, true));
             }
             caseDataUpdated.putAll(confidentialityTabService.updateConfidentialityDetails(caseData));
             caseDataUpdated.putAll(allTabService.getAllTabsFields(caseData));

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/document/DocumentGenService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/document/DocumentGenService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
@@ -56,12 +57,17 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.function.IntFunction;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+import static uk.gov.hmcts.reform.prl.config.DocumentGenerationExecutorConfig.RESUBMISSION_DOCUMENT_EXECUTOR;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C100_CASE_TYPE;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C1A_DRAFT_HINT;
 import static uk.gov.hmcts.reform.prl.constants.PrlAppsConstants.C1A_FINAL_RESPONSE_DOCUMENT;
@@ -370,6 +376,14 @@ public class DocumentGenService {
     private final PdfGenerationService pdfGenerationService;
     private final AuthTokenGenerator authTokenGenerator;
     private final Time dateTime;
+    private Executor resubmissionDocumentExecutor = Runnable::run;
+
+    @Autowired
+    public void setResubmissionDocumentExecutor(
+        @Qualifier(RESUBMISSION_DOCUMENT_EXECUTOR) Executor resubmissionDocumentExecutor
+    ) {
+        this.resubmissionDocumentExecutor = resubmissionDocumentExecutor;
+    }
 
     protected static final String[] ALLOWED_FILE_TYPES = {"jpeg", "jpg", "doc", "docx", "png", "txt"};
 
@@ -429,7 +443,18 @@ public class DocumentGenService {
      */
     public Map<String, Object> createUpdatedCaseDataWithDocuments(String authorisation, CaseData caseData,
                                                                   boolean overrideC100CaseLock) throws Exception {
-        caseData = populateOrganisationDetailsInCaseData(caseData);
+        return createUpdatedCaseDataWithDocuments(
+            authorisation,
+            populateOrganisationDetailsInCaseData(caseData),
+            overrideC100CaseLock,
+            false
+        );
+    }
+
+    private Map<String, Object> createUpdatedCaseDataWithDocuments(String authorisation,
+                                                                   CaseData caseData,
+                                                                   boolean overrideC100CaseLock,
+                                                                   boolean generateConcurrently) throws Exception {
         if (C100_CASE_TYPE.equalsIgnoreCase(caseData.getCaseTypeOfApplication())) {
             caseData = allegationOfHarmRevisedService.updateChildAbusesForDocmosis(caseData);
         }
@@ -439,11 +464,15 @@ public class DocumentGenService {
             authorisation, caseData,
             new HashMap<>(), overrideC100CaseLock
         );
-        if (documentLanguage.isGenEng()) {
-            addEnglishDocumentsToUpdatedCaseData(documentUpdateContext);
-        }
-        if (documentLanguage.isGenWelsh()) {
-            addWelshDocumentsToUpdatedCaseData(documentUpdateContext);
+        if (generateConcurrently) {
+            addResubmissionDocumentsConcurrently(documentUpdateContext, documentLanguage);
+        } else {
+            if (documentLanguage.isGenEng()) {
+                addEnglishDocumentsToUpdatedCaseData(documentUpdateContext);
+            }
+            if (documentLanguage.isGenWelsh()) {
+                addWelshDocumentsToUpdatedCaseData(documentUpdateContext);
+            }
         }
 
         if (documentLanguage.isGenEng() && !documentLanguage.isGenWelsh()) {
@@ -456,6 +485,84 @@ public class DocumentGenService {
             documentUpdateContext.updatedCaseData.put(DOCUMENT_FIELD_C1A, null);
         }
         return documentUpdateContext.updatedCaseData;
+    }
+
+    public Map<String, Object> createUpdatedCaseDataWithDocumentsForC100Resubmission(String authorisation,
+                                                                                     CaseData enrichedCaseData) throws Exception {
+        return createUpdatedCaseDataWithDocuments(authorisation, enrichedCaseData, true, true);
+    }
+
+    private void addResubmissionDocumentsConcurrently(DocumentUpdateContext documentUpdateContext,
+                                                       DocumentLanguage documentLanguage) throws Exception {
+        List<Supplier<Map<String, Object>>> documentTasks = new ArrayList<>();
+        boolean caseNotLocked = isCaseNotLocked(documentUpdateContext);
+
+        if (documentLanguage.isGenEng()) {
+            documentUpdateContext.updatedCaseData.put(ENGDOCGEN, Yes.toString());
+            documentTasks.add(documentUpdateTask(documentUpdateContext, this::addEnglishC8DocumentToUpdatedCaseData));
+            if (caseNotLocked) {
+                documentTasks.add(documentUpdateTask(documentUpdateContext, this::addEnglishC1ADocumentToUpdatedCaseData));
+                documentTasks.add(documentUpdateTask(documentUpdateContext, this::addEnglishC100FinalDocumentToUpdatedCaseData));
+            }
+        }
+        if (documentLanguage.isGenWelsh()) {
+            documentUpdateContext.updatedCaseData.put(IS_WELSH_DOC_GEN, Yes.toString());
+            documentTasks.add(documentUpdateTask(documentUpdateContext, this::addWelshC8DocumentToUpdatedCaseData));
+            if (caseNotLocked) {
+                documentTasks.add(documentUpdateTask(documentUpdateContext, this::addWelshC1ADocumentToUpdatedCaseData));
+                documentTasks.add(documentUpdateTask(documentUpdateContext, this::addWelshC100FinalDocumentToUpdatedCaseData));
+            }
+        }
+
+        mergeDocumentTaskResults(documentUpdateContext.updatedCaseData, documentTasks);
+    }
+
+    private Supplier<Map<String, Object>> documentUpdateTask(DocumentUpdateContext sourceContext,
+                                                              DocumentUpdateOperation operation) {
+        return () -> {
+            Map<String, Object> taskResult = new HashMap<>();
+            DocumentUpdateContext taskContext = new DocumentUpdateContext(
+                sourceContext.authorisation,
+                sourceContext.caseData,
+                taskResult,
+                sourceContext.overrideC100CaseLock
+            );
+            try {
+                operation.update(taskContext);
+                return taskResult;
+            } catch (Exception exception) {
+                throw new CompletionException(exception);
+            }
+        };
+    }
+
+    private void mergeDocumentTaskResults(Map<String, Object> updatedCaseData,
+                                          List<Supplier<Map<String, Object>>> documentTasks) throws Exception {
+        List<CompletableFuture<Map<String, Object>>> futures = documentTasks.stream()
+            .map(task -> CompletableFuture.supplyAsync(task, resubmissionDocumentExecutor))
+            .toList();
+        try {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+            futures.forEach(future -> updatedCaseData.putAll(future.join()));
+        } catch (CompletionException completionException) {
+            futures.forEach(future -> future.cancel(true));
+            Throwable cause = completionException;
+            while (cause instanceof CompletionException && cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            if (cause instanceof Exception exception) {
+                throw exception;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw completionException;
+        }
+    }
+
+    @FunctionalInterface
+    private interface DocumentUpdateOperation {
+        void update(DocumentUpdateContext documentUpdateContext) throws Exception;
     }
 
     private void addWelshDocumentsToUpdatedCaseData(DocumentUpdateContext documentUpdateContext) throws Exception {
@@ -713,79 +820,115 @@ public class DocumentGenService {
             || (caseData.getAllegationOfHarmRevised() != null
             && YesOrNo.Yes.equals(caseData.getAllegationOfHarmRevised().getNewAllegationsOfHarmYesNo()));
 
-        Map<String, Object> updatedCaseData = new HashMap<>(generateC100DraftDocuments(authorisation, caseData));
-        generateDraftEngC1aAndC8DocumentsForResubmission(
+        CaseData applicationDraftCaseData = allegationOfHarmRevisedService.updateChildAbusesForDocmosis(caseData);
+        DocumentLanguage applicationDraftLanguage = documentLanguageService.docGenerateLang(applicationDraftCaseData);
+        Map<String, Object> updatedCaseData = new HashMap<>();
+        List<Supplier<Map<String, Object>>> documentTasks = new ArrayList<>();
+
+        if (applicationDraftLanguage.isGenEng()) {
+            updatedCaseData.put(ENGDOCGEN, Yes.toString());
+            documentTasks.add(documentValueTask(
+                DRAFT_APPLICATION_DOCUMENT_FIELD,
+                () -> getDocument(authorisation, applicationDraftCaseData, DRAFT_HINT, false)
+            ));
+        }
+        if (applicationDraftLanguage.isGenWelsh()) {
+            updatedCaseData.put(IS_WELSH_DOC_GEN, Yes.toString());
+            documentTasks.add(documentValueTask(
+                DRAFT_APPLICATION_DOCUMENT_WELSH_FIELD,
+                () -> getDocument(authorisation, applicationDraftCaseData, DRAFT_HINT, true)
+            ));
+        }
+        addEnglishResubmissionDraftTasks(
             authorisation,
             caseData,
             updatedCaseData,
+            documentTasks,
             documentLanguage,
             isConfidentialInformationPresentForC100,
             isC1aPresentForC100
         );
-        generateDraftWelshC1aAndC8DocumentsForResubmission(
+        addWelshResubmissionDraftTasks(
             authorisation,
             caseData,
             updatedCaseData,
+            documentTasks,
             documentLanguage,
             isConfidentialInformationPresentForC100,
             isC1aPresentForC100
         );
+        try {
+            mergeDocumentTaskResults(updatedCaseData, documentTasks);
+        } catch (RuntimeException runtimeException) {
+            throw runtimeException;
+        } catch (Exception exception) {
+            throw new DocumentGenerationException("Error generating draft documents for resubmission", exception);
+        }
         return updatedCaseData;
     }
 
-    private void generateDraftWelshC1aAndC8DocumentsForResubmission(String authorisation,
-                                                                    CaseData caseData,
-                                                                    Map<String, Object> updatedCaseData,
-                                                                    DocumentLanguage documentLanguage,
-                                                                    boolean isConfidentialInformationPresentForC100,
-                                                                    boolean isC1aPresentForC100) {
-        if (documentLanguage.isGenWelsh()) {
-            if (isConfidentialInformationPresentForC100) {
-                updatedCaseData.put(
-                    DOCUMENT_FIELD_C8_DRAFT_WELSH,
-                    getDocument(authorisation, caseData, C8_DRAFT_HINT, true)
-                );
-            } else {
-                updatedCaseData.put(
-                    DOCUMENT_FIELD_C8_DRAFT_WELSH, null);
-            }
-            if (isC1aPresentForC100) {
-                updatedCaseData.put(
-                    DOCUMENT_FIELD_C1A_DRAFT_WELSH,
-                    getDocument(authorisation, caseData, C1A_DRAFT_HINT, true)
-                );
-            } else {
-                updatedCaseData.put(DOCUMENT_FIELD_C1A_DRAFT_WELSH, null);
-            }
+    private void addEnglishResubmissionDraftTasks(String authorisation,
+                                                  CaseData caseData,
+                                                  Map<String, Object> updatedCaseData,
+                                                  List<Supplier<Map<String, Object>>> documentTasks,
+                                                  DocumentLanguage documentLanguage,
+                                                  boolean confidentialInformationPresent,
+                                                  boolean c1aPresent) {
+        if (!documentLanguage.isGenEng()) {
+            return;
+        }
+        if (confidentialInformationPresent) {
+            documentTasks.add(documentValueTask(
+                DOCUMENT_FIELD_DRAFT_C8,
+                () -> getDocument(authorisation, caseData, C8_DRAFT_HINT, false)
+            ));
+        } else {
+            updatedCaseData.put(DOCUMENT_FIELD_DRAFT_C8, null);
+        }
+        if (c1aPresent) {
+            documentTasks.add(documentValueTask(
+                DOCUMENT_FIELD_DRAFT_C1A,
+                () -> getDocument(authorisation, caseData, C1A_DRAFT_HINT, false)
+            ));
+        } else {
+            updatedCaseData.put(DOCUMENT_FIELD_DRAFT_C1A, null);
         }
     }
 
-    private void generateDraftEngC1aAndC8DocumentsForResubmission(String authorisation,
-                                                                  CaseData caseData,
-                                                                  Map<String, Object> updatedCaseData,
-                                                                  DocumentLanguage documentLanguage,
-                                                                  boolean isConfidentialInformationPresentForC100,
-                                                                  boolean isC1aPresentForC100) {
-        if (documentLanguage.isGenEng()) {
-            if (isConfidentialInformationPresentForC100) {
-                updatedCaseData.put(
-                    DOCUMENT_FIELD_DRAFT_C8,
-                    getDocument(authorisation, caseData, C8_DRAFT_HINT, false)
-                );
-            } else {
-                updatedCaseData.put(
-                    DOCUMENT_FIELD_DRAFT_C8, null);
-            }
-            if (isC1aPresentForC100) {
-                updatedCaseData.put(
-                    DOCUMENT_FIELD_DRAFT_C1A,
-                    getDocument(authorisation, caseData, C1A_DRAFT_HINT, false)
-                );
-
-            } else {
-                updatedCaseData.put(DOCUMENT_FIELD_DRAFT_C1A, null);
-            }
+    private void addWelshResubmissionDraftTasks(String authorisation,
+                                                CaseData caseData,
+                                                Map<String, Object> updatedCaseData,
+                                                List<Supplier<Map<String, Object>>> documentTasks,
+                                                DocumentLanguage documentLanguage,
+                                                boolean confidentialInformationPresent,
+                                                boolean c1aPresent) {
+        if (!documentLanguage.isGenWelsh()) {
+            return;
         }
+        if (confidentialInformationPresent) {
+            documentTasks.add(documentValueTask(
+                DOCUMENT_FIELD_C8_DRAFT_WELSH,
+                () -> getDocument(authorisation, caseData, C8_DRAFT_HINT, true)
+            ));
+        } else {
+            updatedCaseData.put(DOCUMENT_FIELD_C8_DRAFT_WELSH, null);
+        }
+        if (c1aPresent) {
+            documentTasks.add(documentValueTask(
+                DOCUMENT_FIELD_C1A_DRAFT_WELSH,
+                () -> getDocument(authorisation, caseData, C1A_DRAFT_HINT, true)
+            ));
+        } else {
+            updatedCaseData.put(DOCUMENT_FIELD_C1A_DRAFT_WELSH, null);
+        }
+    }
+
+    private Supplier<Map<String, Object>> documentValueTask(String fieldName, Supplier<Object> documentSupplier) {
+        return () -> {
+            Map<String, Object> taskResult = new HashMap<>();
+            taskResult.put(fieldName, documentSupplier.get());
+            return taskResult;
+        };
     }
 
     private Document getDocument(String authorisation, CaseData caseData, String hint, boolean isWelsh,

--- a/src/test/java/uk/gov/hmcts/reform/prl/controllers/ResubmitApplicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/controllers/ResubmitApplicationControllerTest.java
@@ -229,6 +229,10 @@ public class ResubmitApplicationControllerTest {
             .countyLocationCode(123)
             .build();
         when(authorisationService.isAuthorized(any(),any())).thenReturn(true);
+        when(organisationService.getApplicantOrganisationDetails(any(CaseData.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+        when(organisationService.getRespondentOrganisationDetails(any(CaseData.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -267,6 +271,15 @@ public class ResubmitApplicationControllerTest {
                                                                                                           S2S_TOKEN, callbackRequest);
 
         assertEquals(State.SUBMITTED_PAID, response.getData().get("state"));
+        verify(organisationService).getApplicantOrganisationDetails(caseDataGateKeepingMiam);
+        verify(organisationService).getRespondentOrganisationDetails(caseDataGateKeepingMiam);
+        verify(documentGenService).createUpdatedCaseDataWithDocumentsForC100Resubmission(
+            AUTH_TOKEN,
+            caseDataGateKeepingMiam.toBuilder()
+                .state(State.SUBMITTED_PAID)
+                .dateSubmitted(CURRENT_DATE)
+                .build()
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/document/DocumentGenServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/document/DocumentGenServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.reform.prl.enums.YesNoDontKnow;
 import uk.gov.hmcts.reform.prl.enums.YesOrNo;
 import uk.gov.hmcts.reform.prl.exception.InvalidResourceException;
 import uk.gov.hmcts.reform.prl.exception.PdfConversionException;
+import uk.gov.hmcts.reform.prl.framework.exceptions.DocumentGenerationException;
 import uk.gov.hmcts.reform.prl.models.Address;
 import uk.gov.hmcts.reform.prl.models.ContactInformation;
 import uk.gov.hmcts.reform.prl.models.Element;
@@ -71,6 +72,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -81,6 +87,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -2940,6 +2947,73 @@ public class DocumentGenServiceTest {
 
         verifyDocumentsUpdated(stringObjectMap, DOCUMENT_FIELD_DRAFT_C8, DOCUMENT_FIELD_C8_DRAFT_WELSH, DOCUMENT_FIELD_DRAFT_C8,
                                DOCUMENT_FIELD_C1A_DRAFT_WELSH);
+    }
+
+    @Test
+    public void c100ResubmissionUsesFourWorkersForMaximumBilingualCase() throws Exception {
+        DocumentLanguage documentLanguage = DocumentLanguage.builder().isGenEng(true).isGenWelsh(true).build();
+        when(documentLanguageService.docGenerateLang(any(CaseData.class))).thenReturn(documentLanguage);
+        when(allegationOfHarmRevisedService.updateChildAbusesForDocmosis(any(CaseData.class))).thenReturn(c100CaseData);
+
+        AtomicInteger renderCalls = new AtomicInteger();
+        AtomicInteger rendersInFlight = new AtomicInteger();
+        AtomicInteger maximumRendersInFlight = new AtomicInteger();
+        CyclicBarrier firstFourRenders = new CyclicBarrier(4);
+        org.mockito.stubbing.Answer<GeneratedDocumentInfo> concurrentRender = invocation -> {
+            int call = renderCalls.incrementAndGet();
+            int inFlight = rendersInFlight.incrementAndGet();
+            maximumRendersInFlight.accumulateAndGet(inFlight, Math::max);
+            try {
+                if (call <= 4) {
+                    firstFourRenders.await(5, TimeUnit.SECONDS);
+                }
+                return generatedDocumentInfo;
+            } finally {
+                rendersInFlight.decrementAndGet();
+            }
+        };
+
+        doAnswer(concurrentRender).when(dgsService).generateDocument(
+            anyString(), any(CaseDetails.class), any(), any()
+        );
+        doAnswer(concurrentRender).when(dgsService).generateWelshDocument(
+            anyString(), any(CaseDetails.class), any(), any()
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        documentGenService.setResubmissionDocumentExecutor(executor);
+        try {
+            documentGenService.createUpdatedCaseDataWithDocumentsForC100Resubmission(AUTH_TOKEN, c100CaseData);
+            documentGenService.generateDraftDocumentsForC100CaseResubmission(AUTH_TOKEN, c100CaseData);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals(12, renderCalls.get());
+        assertEquals(4, maximumRendersInFlight.get());
+        verifyNoInteractions(organisationService);
+    }
+
+    @Test
+    public void concurrentResubmissionPreservesDocumentGenerationFailure() {
+        DocumentLanguage documentLanguage = DocumentLanguage.builder().isGenEng(true).isGenWelsh(true).build();
+        when(documentLanguageService.docGenerateLang(any(CaseData.class))).thenReturn(documentLanguage);
+        when(allegationOfHarmRevisedService.updateChildAbusesForDocmosis(any(CaseData.class))).thenReturn(c100CaseData);
+        doThrow(new DocumentGenerationException("render failed")).when(dgsService).generateDocument(
+            anyString(), any(CaseDetails.class), any(), any()
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        documentGenService.setResubmissionDocumentExecutor(executor);
+        try {
+            DocumentGenerationException exception = assertThrows(
+                DocumentGenerationException.class,
+                () -> documentGenService.createUpdatedCaseDataWithDocumentsForC100Resubmission(AUTH_TOKEN, c100CaseData)
+            );
+            assertEquals("render failed", exception.getMessage());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-3443


### Change description ###
Improves C100 application resubmission performance by generating independent Docmosis documents concurrently using a configurable four-worker executor.

Also removes duplicate organisation-detail lookups.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
