### PR TITLE
FPVTL-3444 NOC fix

### DIFF
--- a/src/cftlib/java/uk/gov/hmcts/reform/prl/CftLibConfig.java
+++ b/src/cftlib/java/uk/gov/hmcts/reform/prl/CftLibConfig.java
@@ -17,7 +17,7 @@ public class CftLibConfig implements CFTLibConfigurer {
     public void configure(CFTLib lib) throws Exception {
         createCcdRoles(lib);
         configureRoleAssignments(lib);
-        importCcdDefinitions(lib);
+//        importCcdDefinitions(lib);
     }
 
     private void createCcdRoles(CFTLib lib) {

--- a/src/cftlib/java/uk/gov/hmcts/reform/prl/CftLibConfig.java
+++ b/src/cftlib/java/uk/gov/hmcts/reform/prl/CftLibConfig.java
@@ -17,7 +17,7 @@ public class CftLibConfig implements CFTLibConfigurer {
     public void configure(CFTLib lib) throws Exception {
         createCcdRoles(lib);
         configureRoleAssignments(lib);
-//        importCcdDefinitions(lib);
+        importCcdDefinitions(lib);
     }
 
     private void createCcdRoles(CFTLib lib) {

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/UpdatePartyDetailsService.java
@@ -171,8 +171,10 @@ public class UpdatePartyDetailsService {
         updatedCaseData.putAll(caseSummaryTabService.updateTab(caseData));
 
         if (FL401_CASE_TYPE.equals(caseData.getCaseTypeOfApplication())) {
-            updatedCaseData.putAll(noticeOfChangePartiesService.generate(caseData, DARESPONDENT));
-            updatedCaseData.putAll(noticeOfChangePartiesService.generate(caseData, DAAPPLICANT));
+            updatedCaseData.putAll(noticeOfChangePartiesService.generate(
+                caseData, DARESPONDENT, updatedCaseData));
+            updatedCaseData.putAll(noticeOfChangePartiesService.generate(
+                caseData, DAAPPLICANT, updatedCaseData));
 
             PartyDetails fl401Applicant = caseData
                 .getApplicantsFL401();

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/courtnav/CourtNavCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/courtnav/CourtNavCaseService.java
@@ -259,8 +259,10 @@ public class CourtNavCaseService {
         Map<String, Object> data = startAllTabsUpdateDataContent.caseDataMap();
         data.put("id", caseId);
         data.putAll(documentGenService.createUpdatedCaseDataWithDocuments(authToken, objectMapper.convertValue(data, CaseData.class)));
-        data.putAll(noticeOfChangePartiesService.generate(startAllTabsUpdateDataContent.caseData(), DARESPONDENT));
-        data.putAll(noticeOfChangePartiesService.generate(startAllTabsUpdateDataContent.caseData(), DAAPPLICANT));
+        data.putAll(noticeOfChangePartiesService.generate(
+            startAllTabsUpdateDataContent.caseData(), DARESPONDENT, data));
+        data.putAll(noticeOfChangePartiesService.generate(
+            startAllTabsUpdateDataContent.caseData(), DAAPPLICANT, data));
         OrganisationPolicy applicantOrganisationPolicy = OrganisationPolicy.builder().orgPolicyCaseAssignedRole("[APPLICANTSOLICITOR]").build();
         data.put("applicantOrganisationPolicy", applicantOrganisationPolicy);
         data.putAll(partyLevelCaseFlagsService.generateFl401PartyCaseFlags(startAllTabsUpdateDataContent.caseData(),
@@ -287,8 +289,10 @@ public class CourtNavCaseService {
     public void updateCommonSetUpForNoCAndCaseFlags(String caseId) {
         StartAllTabsUpdateDataContent startAllTabsUpdateDataContent = allTabService.getStartAllTabsUpdate(caseId);
         Map<String, Object> caseDataMap = startAllTabsUpdateDataContent.caseDataMap();
-        caseDataMap.putAll(noticeOfChangePartiesService.generate(startAllTabsUpdateDataContent.caseData(), DARESPONDENT));
-        caseDataMap.putAll(noticeOfChangePartiesService.generate(startAllTabsUpdateDataContent.caseData(), DAAPPLICANT));
+        caseDataMap.putAll(noticeOfChangePartiesService.generate(
+            startAllTabsUpdateDataContent.caseData(), DARESPONDENT, caseDataMap));
+        caseDataMap.putAll(noticeOfChangePartiesService.generate(
+            startAllTabsUpdateDataContent.caseData(), DAAPPLICANT, caseDataMap));
         OrganisationPolicy applicantOrganisationPolicy = OrganisationPolicy.builder().orgPolicyCaseAssignedRole("[APPLICANTSOLICITOR]").build();
         caseDataMap.put("applicantOrganisationPolicy", applicantOrganisationPolicy);
         caseDataMap.putAll(partyLevelCaseFlagsService.generateFl401PartyCaseFlags(startAllTabsUpdateDataContent.caseData(),
@@ -307,4 +311,3 @@ public class CourtNavCaseService {
         log.info("Common component setup for NoC and case flags is completed");
     }
 }
-

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesService.java
@@ -652,6 +652,10 @@ public class NoticeOfChangePartiesService {
                         (solicitorRole.getIndex() + 1)
                     ), organisationPolicy
                 );
+            } else if (DARESPONDENT.equals(solicitorRole.getRepresenting())) {
+                OrganisationPolicy organisationPolicy = policyConverter.daGenerate(
+                    solicitorRole, PartyDetails.builder().build());
+                data.put(solicitorRole.getRepresenting().getPolicyFieldTemplate(), organisationPolicy);
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesService.java
@@ -135,6 +135,16 @@ public class NoticeOfChangePartiesService {
         return generate(caseData, representing, POPULATE);
     }
 
+    public Map<String, Object> generate(CaseData caseData,
+                                        SolicitorRole.Representing representing,
+                                        Map<String, Object> existingCaseData) {
+        Map<String, Object> data = generate(caseData, representing);
+        if (FL401_CASE_TYPE.equalsIgnoreCase(caseData.getCaseTypeOfApplication())) {
+            removeExistingCaOrgPolicyPlaceholders(data, existingCaseData);
+        }
+        return data;
+    }
+
     public Map<String, Object> generate(CaseData caseData, SolicitorRole.Representing representing,
                                         NoticeOfChangeAnswersPopulationStrategy strategy) {
         Map<String, Object> data = new HashMap<>();
@@ -236,6 +246,41 @@ public class NoticeOfChangePartiesService {
                 possibleAnswer.ifPresent(answer ->
                                              data.put(representing.getNocAnswersTemplate(), answer)
                 );
+            }
+        }
+
+        generateRequiredCaOrgPoliciesForNoc(data);
+    }
+
+    private void generateRequiredCaOrgPoliciesForNoc(Map<String, Object> data) {
+        List<SolicitorRole> solicitorRoles = new ArrayList<>(SolicitorRole.matchingRoles(CAAPPLICANT));
+        solicitorRoles.addAll(SolicitorRole.matchingRoles(CARESPONDENT));
+        for (SolicitorRole solicitorRole : solicitorRoles) {
+            OrganisationPolicy organisationPolicy = policyConverter.caGenerate(
+                solicitorRole, Optional.empty());
+            data.put(
+                String.format(
+                    solicitorRole.getRepresenting().getPolicyFieldTemplate(),
+                    (solicitorRole.getIndex() + 1)
+                ), organisationPolicy
+            );
+        }
+    }
+
+    private void removeExistingCaOrgPolicyPlaceholders(Map<String, Object> data,
+                                                       Map<String, Object> existingCaseData) {
+        if (existingCaseData == null) {
+            return;
+        }
+        List<SolicitorRole> solicitorRoles = new ArrayList<>(SolicitorRole.matchingRoles(CAAPPLICANT));
+        solicitorRoles.addAll(SolicitorRole.matchingRoles(CARESPONDENT));
+        for (SolicitorRole solicitorRole : solicitorRoles) {
+            String policyField = String.format(
+                solicitorRole.getRepresenting().getPolicyFieldTemplate(),
+                (solicitorRole.getIndex() + 1)
+            );
+            if (existingCaseData.containsKey(policyField)) {
+                data.remove(policyField);
             }
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesServiceTest.java
@@ -2178,7 +2178,7 @@ public class NoticeOfChangePartiesServiceTest {
     }
 
     @Test
-    public void shouldNotCreateDaRespondentPolicyPlaceholderWhenGeneratingForCaRepresenting() {
+    public void shouldCreateDaRespondentPolicyPlaceholderWhenGeneratingForCaRepresenting() {
         Element<PartyDetails> respondent1 = element(UUID.randomUUID(), PartyDetails.builder()
             .firstName("Bob")
             .lastName("Jones")
@@ -2189,11 +2189,16 @@ public class NoticeOfChangePartiesServiceTest {
             .respondents(List.of(respondent1))
             .build();
 
+        OrganisationPolicy daRespondentPolicy = OrganisationPolicy.builder()
+            .orgPolicyCaseAssignedRole("[FL401RESPONDENTSOLICITOR]")
+            .build();
+        when(policyConverter.daGenerate(eq(SolicitorRole.FL401RESPONDENTSOLICITOR), any(PartyDetails.class)))
+            .thenReturn(daRespondentPolicy);
+
         Map<String, Object> result = noticeOfChangePartiesService.generate(
             c100CaseData, SolicitorRole.Representing.CARESPONDENT);
 
-        // DA respondent placeholder should NOT be created - it is handled by its own generate call
-        assertThat(result).doesNotContainKey("daRespondentPolicy");
+        assertThat(result).containsEntry("daRespondentPolicy", daRespondentPolicy);
         assertThat(result).doesNotContainKey("applicantOrganisationPolicy");
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/services/noticeofchange/NoticeOfChangePartiesServiceTest.java
@@ -86,7 +86,6 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -304,7 +303,7 @@ public class NoticeOfChangePartiesServiceTest {
 
         Map<String, Object> test = noticeOfChangePartiesService.generate(caseDataForDa, role.getRepresenting(), strategy);
 
-        assertFalse(test.containsKey("caApplicant3Policy"));
+        assertTrue(test.containsKey("caApplicant3Policy"));
 
     }
 
@@ -2203,7 +2202,7 @@ public class NoticeOfChangePartiesServiceTest {
     }
 
     @Test
-    public void shouldNotCreateCaPolicyPlaceholdersWhenGeneratingForDaRepresenting() {
+    public void shouldCreateCaPolicyPlaceholdersWhenGeneratingForDaRepresenting() {
         PartyDetails fl401Respondent = PartyDetails.builder()
             .representativeFirstName("Rep")
             .representativeLastName("Solicitor")
@@ -2225,8 +2224,40 @@ public class NoticeOfChangePartiesServiceTest {
         Map<String, Object> result = noticeOfChangePartiesService.generate(
             fl401CaseData, SolicitorRole.Representing.DARESPONDENT);
 
-        // CA placeholder policies should NOT be created from FL401 generate
+        assertThat(result).containsKeys("caApplicant1Policy", "caRespondent1Policy");
+    }
+
+    @Test
+    public void shouldNotOverwriteExistingCaPolicyWhenGeneratingForDaRepresenting() {
+        PartyDetails fl401Respondent = PartyDetails.builder()
+            .representativeFirstName("Rep")
+            .representativeLastName("Solicitor")
+            .solicitorOrg(Organisation.builder().organisationID("ORG1").build())
+            .firstName("Resp")
+            .lastName("Party")
+            .build();
+
+        CaseData fl401CaseData = CaseData.builder()
+            .caseTypeOfApplication(FL401_CASE_TYPE)
+            .respondentsFL401(fl401Respondent)
+            .build();
+
+        Map<String, Object> existingCaseData = Map.of(
+            "caApplicant1Policy", OrganisationPolicy.builder()
+                .orgPolicyCaseAssignedRole("[C100APPLICANTSOLICITOR1]")
+                .organisation(Organisation.builder().organisationID("REAL_ORG").build())
+                .build()
+        );
+
+        when(policyConverter.daGenerate(SolicitorRole.FL401RESPONDENTSOLICITOR, fl401Respondent))
+            .thenReturn(OrganisationPolicy.builder().build());
+        when(partiesConverter.generateDaForSubmission(any(PartyDetails.class)))
+            .thenReturn(NoticeOfChangeParties.builder().build());
+
+        Map<String, Object> result = noticeOfChangePartiesService.generate(
+            fl401CaseData, SolicitorRole.Representing.DARESPONDENT, existingCaseData);
+
         assertThat(result).doesNotContainKey("caApplicant1Policy");
-        assertThat(result).doesNotContainKey("caRespondent1Policy");
+        assertThat(result).containsKey("caApplicant2Policy");
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-3444


### Change description ###
Reverted code that was removed during a previous PR merge. 
Even though this is a CA/C100 case, the logic branch is deliberately creating the DA respondent placeholder because ACA’s generic NoC validation still expects an organisation policy for the available [FL401RESPONDENTSOLICITOR] role.

  The NoC challenge question configuration includes both C100 and FL401 solicitor roles. Some FL401 cases did not contain the C100 organisation policy placeholder fields, causing AAC to reject NoC with:

`  {
    "code": "no-org-policy",
    "message": "No Organisation Policy for one or more of the roles available for the notice of change request"
  }`


  ## Changes

  - Adds missing C100 organisation policy placeholders when generating NoC data for FL401 cases.
  - Keeps the existing C100 NoC fix for the missing FL401 respondent policy placeholder.
  - Adds a guarded generation path so existing C100 policy fields on FL401 case data are not overwritten.
  - Updates NoC-related tests to cover:
      - FL401 generation includes required C100 placeholder policies.
      - existing C100 policy fields are preserved.
      - C100 generation includes the required FL401 respondent placeholder.

  ## Validation

  Tested successfully with:

  - Existing FL401 case without linked C100 case.
  - New FL401 case linked to a C100 case.
  - NoC completed successfully and updated the DA applicant organisation policy.
  - Linked C100 metadata remained intact.
  - C100 policy fields on the FL401 case remained empty placeholders.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
